### PR TITLE
Add configurable options: TOC path order and home path

### DIFF
--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -82,6 +82,7 @@ let toc_html
       ?(leaf_href_f : (string -> string) option)
       ?(collapsible = false)
       ?(collapsed_by_default = false)
+      ?(compare_path : (string -> string -> int) option)
       (paths : string list)
   : html
   =
@@ -117,7 +118,7 @@ let toc_html
     in
     "<ul>\n" ^ String.concat ~sep:"\n" items ^ "\n</ul>"
   in
-  render_entries (build_toc_entries paths)
+  render_entries (build_toc_entries ?compare_path paths)
 ;;
 
 let%expect_test "toc_html" =

--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -600,7 +600,9 @@ end
     Always includes a Home link. Adds intermediate directory links as ancestors.
     Does not include the current page itself.
     Example: url_path="/foo/bar/" → Home / foo *)
-let nav_of_url_path ?(home_path = "home.md") (url_path : string) : html =
+let nav_of_url_path ?(home_path = (Config.Home.default).path) (url_path : string)
+  : html
+  =
   let sep : string = {|<span class="sep">/</span>|} in
   let home_href = Html.note_url_path home_path in
   let home : string = {%string|<a href="%{home_href}">Home</a>|} in

--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -33,15 +33,22 @@ type toc_entry =
       }
 
 (** Build a [toc_entry list] from a flat list of relative paths.
-    Paths are grouped by directory, producing nested entries for shared prefixes. *)
-let build_toc_entries (paths : string list) : toc_entry list =
-  let rec build (entries : (string list * string) list) : toc_entry list =
-    let (by_head : (string * (string list * string)) list list) =
+    Paths are grouped by directory, producing nested entries for shared prefixes.
+
+    @param compare_head if given, orders the top-level entries by their head
+      segment; nested levels always sort alphabetically. *)
+let build_toc_entries
+      ?(compare_head : (string -> string -> int) option)
+      (paths : string list)
+  : toc_entry list
+  =
+  let rec build ~(compare : string -> string -> int) entries : toc_entry list =
+    let by_head =
       List.filter_map entries ~f:(fun (segs, path) ->
         match segs with
         | [] -> None
         | hd :: tl -> Some (hd, (tl, path)))
-      |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+      |> List.sort ~compare:(fun (a, _) (b, _) -> compare a b)
       |> List.group ~break:(fun (a, _) (b, _) -> not (String.equal a b))
     in
     List.filter_map by_head ~f:(function
@@ -49,16 +56,17 @@ let build_toc_entries (paths : string list) : toc_entry list =
       | [ (name, ([], path)) ] -> Some (Leaf { name; path })
       | (name, _) :: _ as group ->
         let children = List.map group ~f:snd in
-        Some (Dir { name; children = build children }))
+        Some (Dir { name; children = build ~compare:String.compare children }))
   in
-  build (List.map paths ~f:(fun p -> String.split p ~on:'/', p))
+  let compare = Option.value compare_head ~default:String.compare in
+  build ~compare (List.map paths ~f:(fun p -> String.split p ~on:'/', p))
 ;;
 
 (** Render a table of contents as a nested [<ul>] tree from a list of relative paths.
     Paths are grouped by directory, producing nested lists for shared prefixes.
     Markdown file names are stripped of their extension.
-    [dir_href_f] maps a directory name to an optional href; if [None], no anchor
-    is added to the directory entry. *)
+    @param dir_href_f maps a directory name to an optional href; if [None], no anchor
+      is added to the directory entry. *)
 let toc_html
       ?(dir_href_f = fun dir -> Some (dir ^ "/index"))
       ?(leaf_href_f : (string -> string) option)
@@ -156,12 +164,15 @@ let%expect_test "toc_html" =
     of relative paths. Leaf entries become wikilinks; directories become nested
     sub-lists with either plain text or wikilink labels.
 
-    [path_prefix] is prepended to each entry's path for wikilink resolution.
-    [dir_link] when [true] renders directory labels as wikilinks to
-    [dir/index]; when [false] renders them as plain text. *)
+    @param path_prefix is prepended to each entry's path for wikilink resolution.
+    @param dir_link when [true] renders directory labels as wikilinks to
+      [dir/index]; when [false] renders them as plain text.
+    @param compare_head if given, orders the top-level entries by their head
+      segment; nested levels always sort alphabetically. *)
 let toc_cmark_list
       ?(path_prefix : string = "")
       ?(dir_link : bool = false)
+      ?(compare_head : (string -> string -> int) option)
       (paths : string list)
   : Cmarkit.Block.t
   =
@@ -220,7 +231,7 @@ let toc_cmark_list
     in
     ul items
   in
-  render_entries ~prefix:"" (build_toc_entries paths)
+  render_entries ~prefix:"" (build_toc_entries ?compare_head paths)
 ;;
 
 let%expect_test "toc_cmark_list" =

--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -308,14 +308,12 @@ let%expect_test "toc_cmark_list with compare_path — full-path ordering at ever
 
 (** Create title element for each doc based on their note name.
     Special handling:
-    - for home.md, should be `Home`
     - for dir/index.md, should be `dir`
 *)
 let title_of_path (rel_path : string) : string =
   let basename : string = Filename.basename rel_path in
   let name : string = strip_md_ext basename in
   match name with
-  | "home" -> "Home"
   | "index" ->
     let dir : string = Filename.dirname rel_path in
     Filename.basename dir

--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -275,9 +275,7 @@ let%expect_test "toc_cmark_list with path_prefix" =
     |}]
 ;;
 
-let%expect_test "toc_cmark_list with compare_path — full-path ordering at every \
-                 level"
-  =
+let%expect_test "toc_cmark_list with compare_path — full-path ordering at every level" =
   let paths = [ "guides/a.md"; "guides/b.md"; "intro.md" ] in
   (* Move [guides] ahead of [intro] at the top level, and inside [guides]
      move [b] ahead of [a]. Both rules use full qualified paths. *)
@@ -598,9 +596,7 @@ end
     Always includes a Home link. Adds intermediate directory links as ancestors.
     Does not include the current page itself.
     Example: url_path="/foo/bar/" → Home / foo *)
-let nav_of_url_path ?(home_path = (Config.Home.default).path) (url_path : string)
-  : html
-  =
+let nav_of_url_path ?(home_path = Config.Home.default.path) (url_path : string) : html =
   let sep : string = {|<span class="sep">/</span>|} in
   let home_href = Html.note_url_path home_path in
   let home : string = {%string|<a href="%{home_href}">Home</a>|} in

--- a/pkg/oystermark/lib/component/component.ml
+++ b/pkg/oystermark/lib/component/component.ml
@@ -35,14 +35,25 @@ type toc_entry =
 (** Build a [toc_entry list] from a flat list of relative paths.
     Paths are grouped by directory, producing nested entries for shared prefixes.
 
-    @param compare_head if given, orders the top-level entries by their head
-      segment; nested levels always sort alphabetically. *)
+    @param compare_path if given, orders entries at every level by their full
+      qualified path (the head segment joined to the prefix built from
+      [path_prefix] and ancestor dirs). When omitted, entries sort
+      alphabetically by head segment.
+    @param path_prefix prepended to every path when calling [compare_path], so
+      patterns can match the same way regardless of whether the caller passes
+      root-relative or dir-relative paths. *)
 let build_toc_entries
-      ?(compare_head : (string -> string -> int) option)
+      ?(compare_path : (string -> string -> int) option)
+      ?(path_prefix : string = "")
       (paths : string list)
   : toc_entry list
   =
-  let rec build ~(compare : string -> string -> int) entries : toc_entry list =
+  let rec build ~(prefix : string) entries : toc_entry list =
+    let compare =
+      match compare_path with
+      | Some c -> fun a b -> c (prefix ^ a) (prefix ^ b)
+      | None -> String.compare
+    in
     let by_head =
       List.filter_map entries ~f:(fun (segs, path) ->
         match segs with
@@ -56,10 +67,9 @@ let build_toc_entries
       | [ (name, ([], path)) ] -> Some (Leaf { name; path })
       | (name, _) :: _ as group ->
         let children = List.map group ~f:snd in
-        Some (Dir { name; children = build ~compare:String.compare children }))
+        Some (Dir { name; children = build ~prefix:(prefix ^ name ^ "/") children }))
   in
-  let compare = Option.value compare_head ~default:String.compare in
-  build ~compare (List.map paths ~f:(fun p -> String.split p ~on:'/', p))
+  build ~prefix:path_prefix (List.map paths ~f:(fun p -> String.split p ~on:'/', p))
 ;;
 
 (** Render a table of contents as a nested [<ul>] tree from a list of relative paths.
@@ -167,12 +177,12 @@ let%expect_test "toc_html" =
     @param path_prefix is prepended to each entry's path for wikilink resolution.
     @param dir_link when [true] renders directory labels as wikilinks to
       [dir/index]; when [false] renders them as plain text.
-    @param compare_head if given, orders the top-level entries by their head
-      segment; nested levels always sort alphabetically. *)
+    @param compare_path if given, orders entries at every level by their full
+      qualified path (built from [path_prefix] + ancestor dirs + head). *)
 let toc_cmark_list
       ?(path_prefix : string = "")
       ?(dir_link : bool = false)
-      ?(compare_head : (string -> string -> int) option)
+      ?(compare_path : (string -> string -> int) option)
       (paths : string list)
   : Cmarkit.Block.t
   =
@@ -231,7 +241,7 @@ let toc_cmark_list
     in
     ul items
   in
-  render_entries ~prefix:"" (build_toc_entries ?compare_head paths)
+  render_entries ~prefix:"" (build_toc_entries ?compare_path ~path_prefix paths)
 ;;
 
 let%expect_test "toc_cmark_list" =
@@ -261,6 +271,37 @@ let%expect_test "toc_cmark_list with path_prefix" =
     - y
       - [[x/y/t|t]]
       - [[x/y/z|z]]
+    |}]
+;;
+
+let%expect_test "toc_cmark_list with compare_path — full-path ordering at every \
+                 level"
+  =
+  let paths = [ "guides/a.md"; "guides/b.md"; "intro.md" ] in
+  (* Move [guides] ahead of [intro] at the top level, and inside [guides]
+     move [b] ahead of [a]. Both rules use full qualified paths. *)
+  let rank s =
+    match s with
+    | "guides" -> 0
+    | "guides/b" -> 0
+    | "intro" -> 1
+    | "guides/a" -> 1
+    | _ -> 2
+  in
+  let strip s =
+    match String.chop_suffix s ~suffix:".md" with
+    | Some s -> s
+    | None -> s
+  in
+  let compare_path a b = Int.compare (rank (strip a)) (rank (strip b)) in
+  let block = toc_cmark_list ~compare_path paths in
+  print_endline (Parse.commonmark_of_doc (Cmarkit.Doc.make block));
+  [%expect
+    {|
+    - guides
+      - [[guides/b|b]]
+      - [[guides/a|a]]
+    - [[intro]]
     |}]
 ;;
 

--- a/pkg/oystermark/lib/config/config.ml
+++ b/pkg/oystermark/lib/config/config.ml
@@ -232,6 +232,14 @@ end = struct
   ;;
 end
 
+module Home = struct
+  type t = { path : string [@default "home.md"] }
+  [@@deriving yojson] [@@yojson.allow_extra_fields]
+
+  let default = { path = "home.md" }
+  let t_of_yojson j = or_default ~default t_of_yojson j
+end
+
 module Home_graph_view : sig
   type t =
     { dir : Selector.t (** Dir to use as clusters *)
@@ -283,6 +291,7 @@ type t =
   ; css_snippets : string list [@default []]
   ; pipeline_profile : Pipeline_profile.t [@default Pipeline_profile.default]
   ; home_graph_view : Home_graph_view.t [@default Home_graph_view.default]
+  ; home : Home.t [@default Home.default]
   ; toc_order : Toc_order.t [@default Toc_order.default]
   }
 [@@deriving yojson] [@@yojson.allow_extra_fields]
@@ -293,6 +302,7 @@ let default : t =
   ; css_snippets = []
   ; pipeline_profile = Pipeline_profile.default
   ; home_graph_view = Home_graph_view.default
+  ; home = Home.default
   ; toc_order = Toc_order.default
   }
 ;;
@@ -407,6 +417,7 @@ let%expect_test "of_frontmatter overrides ext_struct" =
         "default_dir": { "include": [ "*" ] },
         "default_tag": "none"
       },
+      "home": { "path": "home.md" },
       "toc_order": [ "*" ]
     }
     |}]
@@ -467,6 +478,7 @@ let%expect_test "Config default" =
         "default_dir": { "include": [ "*" ] },
         "default_tag": "none"
       },
+      "home": { "path": "home.md" },
       "toc_order": [ "*" ]
     }
     |}]

--- a/pkg/oystermark/lib/config/config.ml
+++ b/pkg/oystermark/lib/config/config.ml
@@ -187,9 +187,7 @@ end = struct
       | Some i -> i
       | None -> max_int
     in
-    match
-      find_index (fun p -> (not (is_wildcard p)) && String.equal p name) patterns
-    with
+    match find_index (fun p -> (not (is_wildcard p)) && String.equal p name) patterns with
     | Some i -> i
     | None -> wildcard_rank
   ;;

--- a/pkg/oystermark/lib/config/config.ml
+++ b/pkg/oystermark/lib/config/config.ml
@@ -130,6 +130,71 @@ end
 
 module Pipeline_profile = Make_string_enum (Pipeline_profile_def)
 
+(** Ordering spec for TOC generation.
+
+    A list of name patterns with a single wildcard [*] acting as a placeholder
+    for "everything not otherwise matched". The position of [*] determines
+    where unmatched entries land; items before [*] come first, items after
+    come last.
+
+    Patterns match a TOC entry's top-level segment name (with any [.md]
+    extension stripped). Items with equal rank tiebreak alphabetically.
+
+    Examples:
+    - [\[ "introduction"; "guides"; "*"; "changelog" \]] — fixed head, fixed tail
+    - [\[ "*" \]] (default) — no custom order; everything sorts alphabetically
+    - [\[ "*"; "appendix" \]] — push a specific name to the end *)
+module Toc_order : sig
+  type t = string list
+
+  val default : t
+  val t_of_yojson : J.t -> t
+  val yojson_of_t : t -> J.t
+
+  (** Rank of [name] under [patterns]. Lower ranks sort earlier. *)
+  val rank_of : t -> string -> int
+end = struct
+  type t = string list
+
+  let default : t = [ "*" ]
+
+  let find_index (f : 'a -> bool) (xs : 'a list) : int option =
+    let rec loop i = function
+      | [] -> None
+      | x :: _ when f x -> Some i
+      | _ :: rest -> loop (i + 1) rest
+    in
+    loop 0 xs
+  ;;
+
+  let is_wildcard (s : string) : bool = String.equal s "*"
+
+  let validate (xs : t) : t =
+    let wildcard_count = List.length (List.filter is_wildcard xs) in
+    if wildcard_count > 1 then failwith "toc_order: at most one '*' allowed";
+    xs
+  ;;
+
+  let t_of_yojson (j : J.t) : t =
+    or_default ~default (fun j -> j |> list_of_yojson string_of_yojson |> validate) j
+  ;;
+
+  let yojson_of_t (xs : t) : J.t = yojson_of_list yojson_of_string xs
+
+  let rank_of (patterns : t) (name : string) : int =
+    let wildcard_rank =
+      match find_index is_wildcard patterns with
+      | Some i -> i
+      | None -> max_int
+    in
+    match
+      find_index (fun p -> (not (is_wildcard p)) && String.equal p name) patterns
+    with
+    | Some i -> i
+    | None -> wildcard_rank
+  ;;
+end
+
 (** A selector for include/exclude lists. JSON shape:
     - [`String "all"] -> [Include_all]
     - [`String "none"] -> [Exclude_all]
@@ -218,6 +283,7 @@ type t =
   ; css_snippets : string list [@default []]
   ; pipeline_profile : Pipeline_profile.t [@default Pipeline_profile.default]
   ; home_graph_view : Home_graph_view.t [@default Home_graph_view.default]
+  ; toc_order : Toc_order.t [@default Toc_order.default]
   }
 [@@deriving yojson] [@@yojson.allow_extra_fields]
 
@@ -227,6 +293,7 @@ let default : t =
   ; css_snippets = []
   ; pipeline_profile = Pipeline_profile.default
   ; home_graph_view = Home_graph_view.default
+  ; toc_order = Toc_order.default
   }
 ;;
 
@@ -339,7 +406,8 @@ let%expect_test "of_frontmatter overrides ext_struct" =
         "tag": "all",
         "default_dir": { "include": [ "*" ] },
         "default_tag": "none"
-      }
+      },
+      "toc_order": [ "*" ]
     }
     |}]
 ;;
@@ -348,6 +416,40 @@ let%expect_test "of_frontmatter no oystermark key returns base" =
   let fm : Yaml.value option = Some (`O [ "title", `String "Hello" ]) in
   let merged = fm |> of_frontmatter |> fun fm -> merge default fm in
   assert (merged = default)
+;;
+
+let%expect_test "Toc_order.rank_of" =
+  let patterns = [ "intro"; "guides"; "*"; "changelog" ] in
+  List.iter
+    (fun name -> Printf.printf "%s -> %d\n" name (Toc_order.rank_of patterns name))
+    [ "intro"; "guides"; "random"; "changelog"; "other" ];
+  [%expect
+    {|
+    intro -> 0
+    guides -> 1
+    random -> 2
+    changelog -> 3
+    other -> 2
+    |}]
+;;
+
+let%expect_test "Toc_order no wildcard — unmatched go last" =
+  let patterns = [ "intro"; "guides" ] in
+  List.iter
+    (fun name -> Printf.printf "%s -> %d\n" name (Toc_order.rank_of patterns name))
+    [ "intro"; "other" ];
+  [%expect
+    {|
+    intro -> 0
+    other -> 4611686018427387903
+    |}]
+;;
+
+let%expect_test "Toc_order two wildcards falls back to default" =
+  let j : J.t = `List [ `String "*"; `String "foo"; `String "*" ] in
+  let parsed = Toc_order.t_of_yojson j in
+  print_endline (J.to_string (Toc_order.yojson_of_t parsed));
+  [%expect {| ["*"] |}]
 ;;
 
 let%expect_test "Config default" =
@@ -364,7 +466,8 @@ let%expect_test "Config default" =
         "tag": "all",
         "default_dir": { "include": [ "*" ] },
         "default_tag": "none"
-      }
+      },
+      "toc_order": [ "*" ]
     }
     |}]
 ;;

--- a/pkg/oystermark/lib/config/config.ml
+++ b/pkg/oystermark/lib/config/config.ml
@@ -210,6 +210,8 @@ end = struct
   let t_of_yojson j = or_default ~default t_of_yojson j
 end
 
+(** {1 Config config} *)
+
 type t =
   { ext_struct : Ext_struct.t [@default Ext_struct.default]
   ; theme : Theme.t [@default Theme.default]
@@ -262,8 +264,7 @@ let merge (base : t) (overlay : t) : t =
   t_of_yojson j
 ;;
 
-(* Per-file config from frontmatter
-   ================================ *)
+(** {1 Per-file config from frontmatter} *)
 
 (** Convert a [Yaml.value] to [Yojson.Safe.t]. *)
 let rec yaml_to_yojson : Yaml.value -> J.t = function
@@ -292,6 +293,8 @@ let of_frontmatter ?(default = default) ?(config_key = "oyster") (fm : Yaml.valu
        or_default ~default t_of_yojson (merge_json base_j overlay_j))
   | Some _ -> default
 ;;
+
+(** {1 Tests} *)
 
 (* Wire-format contract with [static/graph_view/config.d.ts]
    ----------

--- a/pkg/oystermark/lib/oystermark.ml
+++ b/pkg/oystermark/lib/oystermark.ml
@@ -78,6 +78,7 @@ let render_vault
       ~leaf_href_f:Html.file_url_path
       ~collapsible:true
       ~collapsed_by_default:true
+      ~compare_path:(Pipeline.compare_path_of_toc_order config.toc_order)
       sidebar_paths
   in
   List.filter_map final_vault.docs ~f:(fun (rel_path, final) ->

--- a/pkg/oystermark/lib/oystermark.ml
+++ b/pkg/oystermark/lib/oystermark.ml
@@ -90,8 +90,10 @@ let render_vault
       let body = Html.of_doc ~backend_blocks ~safe ~config final in
       let url_path = Html.note_url_path rel_path in
       let title : string = Component.title_of_path rel_path in
-      let nav : string = Component.nav_of_url_path url_path in
-      let sidebar : string = if String.equal rel_path "home.md" then "" else sidebar in
+      let nav : string = Component.nav_of_url_path ~home_path:config.home.path url_path in
+      let sidebar : string =
+        if String.equal rel_path config.home.path then "" else sidebar
+      in
       let page = Theme.{ title; body; url_path; nav; sidebar } in
       let html = theme page in
       Some (Html.note_output_path rel_path, html))

--- a/pkg/oystermark/lib/pipeline/pipeline.ml
+++ b/pkg/oystermark/lib/pipeline/pipeline.ml
@@ -15,7 +15,7 @@ include On_parse
 include Code_exec_
 
 (** Add TOC to page named "home.md".
-    [dir_link] controls whether directory entries in the TOC are rendered as
+    @param dir_link controls whether directory entries in the TOC are rendered as
     wikilinks (to [dir/index]) or plain text.  Set to [true] when [dir_index]
     is also in the pipeline. *)
 let home_toc ?(dir_link : bool = false) () : t =

--- a/pkg/oystermark/lib/pipeline/pipeline.ml
+++ b/pkg/oystermark/lib/pipeline/pipeline.ml
@@ -39,7 +39,7 @@ let compare_path_of_toc_order (toc_order : Config.Toc_order.t) : string -> strin
 let home_toc
       ?(dir_link : bool = false)
       ?(toc_order : Config.Toc_order.t = Config.Toc_order.default)
-      ?(home_path : string = (Config.Home.default).path)
+      ?(home_path : string = Config.Home.default.path)
       ()
   : t
   =
@@ -161,7 +161,7 @@ let backlinks : t =
     default. See {!Config.Home} for [home_path]. *)
 let home_graph
       ?(config : Config.Home_graph_view.t = Config.Home_graph_view.default)
-      ?(home_path : string = (Config.Home.default).path)
+      ?(home_path : string = Config.Home.default.path)
       ()
   : t
   =

--- a/pkg/oystermark/lib/pipeline/pipeline.ml
+++ b/pkg/oystermark/lib/pipeline/pipeline.ml
@@ -30,21 +30,23 @@ let compare_path_of_toc_order (toc_order : Config.Toc_order.t) : string -> strin
     if ra <> rb then Int.compare ra rb else String.compare a b
 ;;
 
-(** Add TOC to page named "home.md".
+(** Add TOC to the home page.
     @param dir_link controls whether directory entries in the TOC are rendered as
     wikilinks (to [dir/index]) or plain text.  Set to [true] when [dir_index]
     is also in the pipeline.
-    @param toc_order orders top-level TOC entries; see {!Config.Toc_order}. *)
+    @param toc_order orders top-level TOC entries; see {!Config.Toc_order}.
+    @param home_path path of the home page; see {!Config.Home}. *)
 let home_toc
       ?(dir_link : bool = false)
       ?(toc_order : Config.Toc_order.t = Config.Toc_order.default)
+      ?(home_path : string = (Config.Home.default).path)
       ()
   : t
   =
   let compare_path = compare_path_of_toc_order toc_order in
   let on_vault : Vault.t -> Vault.t =
     map_each_doc (fun (ctx : Vault.t) (path : string) (doc : Cmarkit.Doc.t) ->
-      if not (String.equal path "home.md")
+      if not (String.equal path home_path)
       then [ path, doc ]
       else (
         let toc_paths : string list =
@@ -154,10 +156,13 @@ let backlinks : t =
   make ~on_vault ()
 ;;
 
-(** Append an interactive graph widget to [home.md].
+(** Append an interactive graph widget to the home page.
     [view] controls which dir/tag clusters appear and which are selected by
-    default. *)
-let home_graph ?(config : Config.Home_graph_view.t = Config.Home_graph_view.default) ()
+    default. See {!Config.Home} for [home_path]. *)
+let home_graph
+      ?(config : Config.Home_graph_view.t = Config.Home_graph_view.default)
+      ?(home_path : string = (Config.Home.default).path)
+      ()
   : t
   =
   let open Vault_graph in
@@ -167,7 +172,7 @@ let home_graph ?(config : Config.Home_graph_view.t = Config.Home_graph_view.defa
     let html = to_widget_html ~config g in
     let docs =
       List.map ctx.docs ~f:(fun (path, doc) ->
-        if not (String.equal path "home.md")
+        if not (String.equal path home_path)
         then path, doc
         else (
           let block_mapper = add_html_code_block `Append html in
@@ -196,8 +201,8 @@ let default ?(cache : Cache.cache option) ?(config : Config.t = Config.default) 
   >> py_executor ?cache ()
   >> dot_render ()
   >> backlinks
-  >> home_graph ~config:config.home_graph_view ()
-  >> home_toc ~dir_link:true ~toc_order:config.toc_order ()
+  >> home_graph ~config:config.home_graph_view ~home_path:config.home.path ()
+  >> home_toc ~dir_link:true ~toc_order:config.toc_order ~home_path:config.home.path ()
   >> dir_index ~toc_order:config.toc_order ()
 ;;
 

--- a/pkg/oystermark/lib/pipeline/pipeline.ml
+++ b/pkg/oystermark/lib/pipeline/pipeline.ml
@@ -14,11 +14,33 @@ include On_discover
 include On_parse
 include Code_exec_
 
+(** Top-level comparator for TOC entries from a {!Config.Toc_order.t}.
+    Ranks by [toc_order], tiebreaking alphabetically. Strips [.md] before
+    matching so patterns like ["readme"] match both leaves and dirs. *)
+let compare_head_of_toc_order (toc_order : Config.Toc_order.t) : string -> string -> int =
+  let strip (s : string) : string =
+    match String.chop_suffix s ~suffix:".md" with
+    | Some s -> s
+    | None -> s
+  in
+  fun a b ->
+    let ra = Config.Toc_order.rank_of toc_order (strip a) in
+    let rb = Config.Toc_order.rank_of toc_order (strip b) in
+    if ra <> rb then Int.compare ra rb else String.compare a b
+;;
+
 (** Add TOC to page named "home.md".
     @param dir_link controls whether directory entries in the TOC are rendered as
     wikilinks (to [dir/index]) or plain text.  Set to [true] when [dir_index]
-    is also in the pipeline. *)
-let home_toc ?(dir_link : bool = false) () : t =
+    is also in the pipeline.
+    @param toc_order orders top-level TOC entries; see {!Config.Toc_order}. *)
+let home_toc
+      ?(dir_link : bool = false)
+      ?(toc_order : Config.Toc_order.t = Config.Toc_order.default)
+      ()
+  : t
+  =
+  let compare_head = compare_head_of_toc_order toc_order in
   let on_vault : Vault.t -> Vault.t =
     map_each_doc (fun (ctx : Vault.t) (path : string) (doc : Cmarkit.Doc.t) ->
       if not (String.equal path "home.md")
@@ -28,7 +50,7 @@ let home_toc ?(dir_link : bool = false) () : t =
           List.filter_map (Vault.all_entry_paths ctx) ~f:(fun p ->
             if String.is_suffix p ~suffix:"/" then None else Some p)
         in
-        let toc_cmark_list = Component.toc_cmark_list ~dir_link toc_paths in
+        let toc_cmark_list = Component.toc_cmark_list ~dir_link ~compare_head toc_paths in
         let block_mapper = add_block `Append toc_cmark_list in
         let mapper = Cmarkit.Mapper.make ~block:block_mapper () in
         let new_home = Cmarkit.Mapper.map_doc mapper doc in
@@ -40,10 +62,18 @@ let home_toc ?(dir_link : bool = false) () : t =
 (** Generate an index page for each directory entry.
     For a dir path like [subdir/], emits [(subdir/index.md, toc_doc)] where
     [toc_doc] is a page listing the directory's children.
-    [immediate_only] when [true] lists only direct children (files and subdirs);
-    when [false] lists all descendants as a nested tree.
-    Skips if [dir/index.md] already exists in the vault. *)
-let dir_index ?(immediate_only : bool = false) () : t =
+    Skips if [dir/index.md] already exists in the vault.
+    @param immediate_only when [true] lists only direct children (files and subdirs);
+      when [false] lists all descendants as a nested tree.
+    @param toc_order the order to use for TOC entries.
+     *)
+let dir_index
+      ?(immediate_only : bool = false)
+      ?(toc_order : Config.Toc_order.t = Config.Toc_order.default)
+      ()
+  : t
+  =
+  let compare_head = compare_head_of_toc_order toc_order in
   let on_vault (ctx : Vault.t) : Vault.t =
     let doc_paths : string list = List.map ctx.docs ~f:fst in
     let non_empty_dirs : string list =
@@ -89,7 +119,11 @@ let dir_index ?(immediate_only : bool = false) () : t =
                 else None)
             in
             let toc_block : Cmarkit.Block.t =
-              Component.toc_cmark_list ~path_prefix:dir_path ~dir_link:true rel_children
+              Component.toc_cmark_list
+                ~path_prefix:dir_path
+                ~dir_link:true
+                ~compare_head
+                rel_children
             in
             Some (index_path, Cmarkit.Doc.make toc_block))))
     in
@@ -162,8 +196,8 @@ let default ?(cache : Cache.cache option) ?(config : Config.t = Config.default) 
   >> dot_render ()
   >> backlinks
   >> home_graph ~config:config.home_graph_view ()
-  >> home_toc ~dir_link:true ()
-  >> dir_index ()
+  >> home_toc ~dir_link:true ~toc_order:config.toc_order ()
+  >> dir_index ~toc_order:config.toc_order ()
 ;;
 
 let basic : t = id >> backlinks

--- a/pkg/oystermark/lib/pipeline/pipeline.ml
+++ b/pkg/oystermark/lib/pipeline/pipeline.ml
@@ -14,10 +14,11 @@ include On_discover
 include On_parse
 include Code_exec_
 
-(** Top-level comparator for TOC entries from a {!Config.Toc_order.t}.
-    Ranks by [toc_order], tiebreaking alphabetically. Strips [.md] before
-    matching so patterns like ["readme"] match both leaves and dirs. *)
-let compare_head_of_toc_order (toc_order : Config.Toc_order.t) : string -> string -> int =
+(** Full-path comparator for TOC entries from a {!Config.Toc_order.t}.
+    Ranks each path by [toc_order], tiebreaking alphabetically. Strips [.md]
+    before matching so a pattern like ["guides/intro"] matches both
+    ["guides/intro.md"] (leaf) and ["guides/intro"] (dir). *)
+let compare_path_of_toc_order (toc_order : Config.Toc_order.t) : string -> string -> int =
   let strip (s : string) : string =
     match String.chop_suffix s ~suffix:".md" with
     | Some s -> s
@@ -40,7 +41,7 @@ let home_toc
       ()
   : t
   =
-  let compare_head = compare_head_of_toc_order toc_order in
+  let compare_path = compare_path_of_toc_order toc_order in
   let on_vault : Vault.t -> Vault.t =
     map_each_doc (fun (ctx : Vault.t) (path : string) (doc : Cmarkit.Doc.t) ->
       if not (String.equal path "home.md")
@@ -50,7 +51,7 @@ let home_toc
           List.filter_map (Vault.all_entry_paths ctx) ~f:(fun p ->
             if String.is_suffix p ~suffix:"/" then None else Some p)
         in
-        let toc_cmark_list = Component.toc_cmark_list ~dir_link ~compare_head toc_paths in
+        let toc_cmark_list = Component.toc_cmark_list ~dir_link ~compare_path toc_paths in
         let block_mapper = add_block `Append toc_cmark_list in
         let mapper = Cmarkit.Mapper.make ~block:block_mapper () in
         let new_home = Cmarkit.Mapper.map_doc mapper doc in
@@ -73,7 +74,7 @@ let dir_index
       ()
   : t
   =
-  let compare_head = compare_head_of_toc_order toc_order in
+  let compare_path = compare_path_of_toc_order toc_order in
   let on_vault (ctx : Vault.t) : Vault.t =
     let doc_paths : string list = List.map ctx.docs ~f:fst in
     let non_empty_dirs : string list =
@@ -122,7 +123,7 @@ let dir_index
               Component.toc_cmark_list
                 ~path_prefix:dir_path
                 ~dir_link:true
-                ~compare_head
+                ~compare_path
                 rel_children
             in
             Some (index_path, Cmarkit.Doc.make toc_block))))

--- a/pkg/oystermark/lib/pp_struct/dune
+++ b/pkg/oystermark/lib/pp_struct/dune
@@ -13,9 +13,13 @@
  (libraries cmarkit core parse component oystermark))
 
 (rule
- (with-stdout-to t1.output (run ./t1.exe)))
+ (with-stdout-to
+  t1.output
+  (run ./t1.exe)))
 
 (rule
  (alias runtest)
- (mode (promote (until-clean)))
- (action (diff t1.expected.html t1.output)))
+ (mode
+  (promote (until-clean)))
+ (action
+  (diff t1.expected.html t1.output)))


### PR DESCRIPTION
- **CHORE**
- **add toc-order config**
- **add toc order arg to dir_index and home_toc pipeline**
- **full path compare**
- **apply order to sidebar toc**
- **add home page config**
- **remove upper case special handling for home.md**
- **fmt**
