### PR TITLE
Switch to parser-injected heading id + LSP: daily notes, command blocks, and oysterlsp.json

### DIFF
--- a/pkg/oystermark/docs/dune
+++ b/pkg/oystermark/docs/dune
@@ -51,6 +51,7 @@
   feature-attribute-anchors
   feature-codeaction-create-unresolved-link
   feature-completion
+  feature-daily-notes
   feature-diagnostics
   feature-document-outline
   feature-document-sync

--- a/pkg/oystermark/docs/dune
+++ b/pkg/oystermark/docs/dune
@@ -51,6 +51,7 @@
   feature-attribute-anchors
   feature-codeaction-create-unresolved-link
   feature-completion
+  feature-configuration
   feature-daily-notes
   feature-diagnostics
   feature-document-outline

--- a/pkg/oystermark/docs/dune
+++ b/pkg/oystermark/docs/dune
@@ -50,6 +50,7 @@
   design-index
   feature-attribute-anchors
   feature-codeaction-create-unresolved-link
+  feature-command-block
   feature-completion
   feature-configuration
   feature-daily-notes

--- a/pkg/oystermark/lib/component/html.ml
+++ b/pkg/oystermark/lib/component/html.ml
@@ -748,7 +748,7 @@ let%expect_test "block attribute on paragraph" =
   let open For_test in
   let doc = Parse.of_string "{#water .important key=\"my val\"}\nDon't forget!" in
   Format.printf "%a%!" (pp_doc `Plain) doc;
-  [%expect {| <p id="water" class="important" key="my val">Don't forget!</p> |}]
+  [%expect {| <p id="water" class="important" key="my val">Don’t forget!</p> |}]
 ;;
 
 let%expect_test "block attribute on heading combines with slug; attr id wins" =

--- a/pkg/oystermark/lib/component/html.ml
+++ b/pkg/oystermark/lib/component/html.ml
@@ -9,7 +9,6 @@ module C = Cmarkit_renderer.Context
 module Resolve = Vault.Resolve
 module Embed = Vault.Embed
 module Cb_attribute = Parse.Cb_attribute
-module Heading_slug = Parse.Heading_slug
 module H = Tyxml.Html
 
 let elt_to_string (e : 'a H.elt) : string = Format.asprintf "%a" (H.pp_elt ()) e
@@ -571,14 +570,17 @@ let render_block
         ()
   in
   function
-  | Block.Heading (h, meta) ->
-    let slug = Meta.find Heading_slug.meta_key meta in
+  | Block.Heading (h, _meta) ->
+    let slug = Parse.Common.heading_id h in
     (match slug, attr with
      | None, None -> false
      | _, _ ->
        let level = Block.Heading.level h in
        (* The attribute id wins over the auto slug if both present (djot says
-          last id wins; the user-written attribute is more specific). *)
+          last id wins; the user-written attribute is more specific). The parser
+          resolves this too — with [~heading_auto_ids:true] an explicit [ {#id} ]
+          is what {!Parse.Common.heading_id} returns — so the two agree; the
+          branch stays for headings not parsed by {!Parse.of_string}. *)
        let id_attr =
          match attr_id, slug with
          | Some id, _ -> sprintf " id=\"%s\"" id

--- a/pkg/oystermark/lib/parse/common.ml
+++ b/pkg/oystermark/lib/parse/common.ml
@@ -31,6 +31,26 @@ let compose_inline_maps (ms : Inline.t Mapper.mapper list) =
   List.fold_right ms ~init:(fun m i -> Mapper.default) ~f:compose_inline_map
 ;;
 
+let heading_id (h : Block.Heading.t) : string option =
+  match Block.Heading.id h with
+  | Some (`Auto id | `Id id) -> Some id
+  | None -> None
+;;
+
+(** The identifier the parser would derive from heading text [s]. For resolving a
+    link fragment written as text, e.g. a wikilink [ [[note#Some Heading]] ] —
+    against {!heading_id}. Matches the first heading of that text. *)
+let heading_id_of_text (s : string) : string =
+  Inline.id (Inline.Text (s, Meta.none))
+;;
+
+(** Render inlines to plain text, losing their markdown syntax. Used to render a
+    heading to the plain text that names it. *)
+let inline_to_plain_text (inline : Inline.t) : string =
+  let lines = Inline.to_plain_text ~break_on_soft:false inline in
+  String.concat ~sep:"\n" (List.map lines ~f:(String.concat ~sep:""))
+;;
+
 (** Reconstruct a fork {!Cmarkit.Block.Div.t} with a new [body], preserving its
     indent/fences/class so commonmark roundtrip is unaffected. Used by passes
     that recurse into a div's body (e.g. Struct, block attributes). *)

--- a/pkg/oystermark/lib/parse/common.ml
+++ b/pkg/oystermark/lib/parse/common.ml
@@ -23,11 +23,11 @@ let compose_inline_map (m1 : Inline.t Mapper.mapper) (m2 : Inline.t Mapper.mappe
      | other -> other)
 ;;
 
-let compose_all_block_maps (ms : Block.t Mapper.mapper list) =
+let compose_block_maps (ms : Block.t Mapper.mapper list) =
   List.fold_right ms ~init:(fun m b -> Mapper.default) ~f:compose_block_map
 ;;
 
-let compose_all_inline_maps (ms : Inline.t Mapper.mapper list) =
+let compose_inline_maps (ms : Inline.t Mapper.mapper list) =
   List.fold_right ms ~init:(fun m i -> Mapper.default) ~f:compose_inline_map
 ;;
 

--- a/pkg/oystermark/lib/parse/extract.ml
+++ b/pkg/oystermark/lib/parse/extract.ml
@@ -12,8 +12,8 @@ let rec flatten (blocks : Cmarkit.Block.t list) : Cmarkit.Block.t list =
     | other -> [ other ])
 ;;
 
-(** Collect the section starting at the heading with id stamped in
-    {!module:Heading_slug}, up to (but not including) the
+(** Collect the section starting at the heading whose identifier (see
+    {!Common.heading_id}) is [heading_id], up to (but not including) the
     next heading of equal or lesser level.  Returns [] when the heading is not
     found. *)
 let get_heading_section (blocks : Cmarkit.Block.t list) (heading_id : string)
@@ -28,8 +28,8 @@ let get_heading_section (blocks : Cmarkit.Block.t list) (heading_id : string)
     | [] -> None
     | block :: rest ->
       (match block with
-       | Block.Heading (h, meta) ->
-         (match Meta.find Heading_slug.meta_key meta with
+       | Block.Heading (h, _meta) ->
+         (match Common.heading_id h with
           | Some id when String.equal id heading_id ->
             Some (block, Block.Heading.level h, rest)
           | _ -> find_heading rest)

--- a/pkg/oystermark/lib/parse/heading_slug.ml
+++ b/pkg/oystermark/lib/parse/heading_slug.ml
@@ -1,9 +1,24 @@
-(** Add slug to the metadata of headings
+(** Add slug to the metadata of headings.
 
-    Heading slug generation: GitHub-style anchors with deduplication.
+    {b Deprecated, and no longer wired into {!Oystermark.Parse.of_string}.} The
+    parser assigns heading identifiers itself now: [Doc.of_string] is called with
+    [~heading_auto_ids:true] and the identifier lives in {!Cmarkit.Block.Heading.id},
+    read via {!Common.heading_id}. Nothing stamps {!meta_key} any more, so
+    {!sexp_of_meta} prints nothing and {!mk_block_map} is unused.
 
-    Slugs are stamped onto heading blocks' [Cmarkit.Meta.t] during parsing,
-    providing a single source of truth for heading identifiers. *)
+    It is kept for reference, because it documents what oyster used to mean by a
+    heading identifier and the two differ:
+
+    - {!slugify} is GitHub-style — every non-alphanumeric byte becomes [-], runs
+      collapse, case is folded — whereas the parser follows CommonMark's
+      {!Cmarkit.Inline.id}, which {e drops} punctuation instead: [foo/bar] was
+      [foo-bar] and is now [foobar].
+    - Deduplication was over one pass of one document, keyed by base slug. The
+      parser's is in document order and counts explicit [ {#id} ] attributes as
+      taken.
+
+    New code must read {!Common.heading_id}, or {!Common.heading_id_of_text} to
+    resolve a fragment written as text. *)
 
 open Core
 
@@ -34,22 +49,10 @@ let dedup_slug (seen : (string, int) Hashtbl.t) (text : string) : string =
   if count = 0 then base else sprintf "%s-%d" base count
 ;;
 
-(** Render inlines to plain text, losing their markdown syntax. Used in rendering
-    heading to plain text. *)
-let inline_to_plain_text (inline : Cmarkit.Inline.t) : string =
-  let lines =
-    Cmarkit.Inline.to_plain_text
-      ~ext:(fun ~break_on_soft inline ->
-        match inline with
-        | Cmarkit.Inline.Ext_wikilink (wl, _meta) ->
-          let text = Cmarkit.Inline.Wikilink.to_plain_text wl in
-          Cmarkit.Inline.Text (text, Cmarkit.Meta.none)
-        | other -> other)
-      ~break_on_soft:false
-      inline
-  in
-  String.concat ~sep:"\n" (List.map lines ~f:(String.concat ~sep:""))
-;;
+(** Moved to {!Common.inline_to_plain_text}, which no longer needs an [~ext] for
+    wikilinks: [Cmarkit.Inline.to_plain_text] handles
+    [Cmarkit.Inline.Ext_wikilink] itself. *)
+let inline_to_plain_text = Common.inline_to_plain_text
 
 let mk_block_map () : Cmarkit.Block.t Cmarkit.Mapper.mapper =
   let open Cmarkit.Mapper in

--- a/pkg/oystermark/lib/parse/parse.ml
+++ b/pkg/oystermark/lib/parse/parse.ml
@@ -62,11 +62,22 @@ let of_string
       ~locs:true
       ~heading_auto_ids:true
       ~block_id:true
-      ~div:true
       ~wikilink:true
+      ~callout:(Block.Callout.Config.make ())
+      (* Djot extensions begin *)
+      ~div:true
       ~inline_attributes:true
       ~block_attributes:true
-      ~callout:(Block.Callout.Config.make ())
+      ~intraword_emphasis:true
+      ~marked_emphasis_delims:true
+      ~extra_inline_containers:Inline.Extra_inline_container.Config.djot
+      ~underscore_thematic_break:true
+      ~colon_symbols:true
+      ~extended_ordered_list_styles:true
+      ~table_captions:true
+      ~multiline_atx_headings:true
+      ~smart_punctuation:true
+      (* Djot extensions end *)
       body
   in
   let body_doc = Mapper.map_doc (mk_mapper ()) cmarkit_doc in

--- a/pkg/oystermark/lib/parse/parse.ml
+++ b/pkg/oystermark/lib/parse/parse.ml
@@ -64,14 +64,15 @@ let of_string
       ~block_id:true
       ~wikilink:true
       ~callout:(Block.Callout.Config.make ())
+      (* CommonMark behaviors the djot preset would disable. Kept on. *)
+      ~intraword_emphasis:true
+      ~underscore_thematic_break:true
       (* Djot extensions begin *)
       ~div:true
       ~inline_attributes:true
       ~block_attributes:true
-      ~intraword_emphasis:true
       ~marked_emphasis_delims:true
       ~extra_inline_containers:Inline.Extra_inline_container.Config.djot
-      ~underscore_thematic_break:true
       ~colon_symbols:true
       ~extended_ordered_list_styles:true
       ~table_captions:true

--- a/pkg/oystermark/lib/parse/parse.ml
+++ b/pkg/oystermark/lib/parse/parse.ml
@@ -34,7 +34,7 @@ let mk_mapper () : Cmarkit.Mapper.t =
   Cmarkit.Mapper.make
     ~inline_ext_default:(fun _m i -> Some i)
     ~block:
-      (compose_all_block_maps [ Heading_slug.mk_block_map (); Cb_attribute.block_map ])
+      (compose_block_maps [ Heading_slug.mk_block_map (); Cb_attribute.block_map ])
     ()
 ;;
 

--- a/pkg/oystermark/lib/parse/parse.ml
+++ b/pkg/oystermark/lib/parse/parse.ml
@@ -18,7 +18,6 @@ open Core
 open Common
 module Common = Common
 module Frontmatter = Frontmatter
-module Heading_slug = Heading_slug
 module Cb_attribute = Cb_attribute
 module Textloc_conv = Textloc_conv
 module Struct = Struct
@@ -33,15 +32,14 @@ type block_id =
 let mk_mapper () : Cmarkit.Mapper.t =
   Cmarkit.Mapper.make
     ~inline_ext_default:(fun _m i -> Some i)
-    ~block:
-      (compose_block_maps [ Heading_slug.mk_block_map (); Cb_attribute.block_map ])
+    ~block:(compose_block_maps [ Cb_attribute.block_map ])
     ()
 ;;
 
 (** [of_string ?strict ?layout s] parses markdown string [s] into a
     [Cmarkit.Doc.t] with frontmatter embedded as a {!Frontmatter.Frontmatter}
-    block and wikilinks/block IDs parsed. Heading slugs are stamped onto
-    heading block metadata. *)
+    block and wikilinks/block IDs parsed. Heading identifiers are assigned by the
+    parser ([~heading_auto_ids:true]) and read via {!Common.heading_id}. *)
 let of_string
       (* Cmarkit config *)
       ?(strict = false)
@@ -62,6 +60,7 @@ let of_string
       ~strict
       ~layout
       ~locs:true
+      ~heading_auto_ids:true
       ~block_id:true
       ~div:true
       ~wikilink:true
@@ -208,12 +207,7 @@ let sexp_of_ =
       ; Struct.sexp_of_block
       ; block_attributes_sexp_of_block
       ]
-    ~metas:
-      [ Heading_slug.sexp_of_meta
-      ; block_id_sexp_of_meta
-      ; callout_sexp_of_meta
-      ; Cb_attribute.sexp_of_meta
-      ]
+    ~metas:[ block_id_sexp_of_meta; callout_sexp_of_meta; Cb_attribute.sexp_of_meta ]
     ()
 ;;
 

--- a/pkg/oystermark/lib/vault/index.ml
+++ b/pkg/oystermark/lib/vault/index.ml
@@ -7,7 +7,9 @@ type heading_entry =
   { text : string
   ; level : int
   ; slug : string
-    (** GitHub-style anchor: lowercase, punctuation stripped, deduped with [-1], [-2], etc. *)
+    (** The identifier the parser gave the heading: case-folded, punctuation
+        dropped, spaces to [-], deduped with [-1], [-2], … See
+        {!Parse.Common.heading_id}. *)
   ; loc : Cmarkit.Textloc.t option
   }
 
@@ -40,7 +42,7 @@ type t =
   }
 
 (* Use Cmarkit.Folder to extract headings from a document.
-   Reads slugs from heading block meta (stamped during parsing). *)
+   Reads the identifier the parser assigned, see {!Parse.Common.heading_id}. *)
 let extract_headings (doc : Cmarkit.Doc.t) : heading_entry list =
   let folder =
     Cmarkit.Folder.make
@@ -48,12 +50,12 @@ let extract_headings (doc : Cmarkit.Doc.t) : heading_entry list =
         match block with
         | Cmarkit.Block.Heading (h, meta) ->
           let level = Cmarkit.Block.Heading.level h in
-          let text = Heading_slug.inline_to_plain_text (Cmarkit.Block.Heading.inline h) in
+          let text = Common.inline_to_plain_text (Cmarkit.Block.Heading.inline h) in
           let slug =
-            Cmarkit.Meta.find Heading_slug.meta_key meta
+            Common.heading_id h
             |> Option.value_exn
                  ~message:
-                   "heading missing slug meta — doc must be parsed via Parse.of_string"
+                   "heading missing identifier — doc must be parsed via Parse.of_string"
           in
           let loc =
             let tl = Cmarkit.Meta.textloc meta in
@@ -98,10 +100,10 @@ let extract_block_ids (doc : Cmarkit.Doc.t) : block_entry list =
 
 (* Extract explicit djot attribute ids ([{#id}]) from a document.
 
-   Attribute ids come from three AST sources (see {!page-"feature-attribute-anchors"}):
-   - [Block.Ext_attributes]: a djot attribute line attached to a block.
+   Attribute ids come from two AST sources (see {!page-"feature-attribute-anchors"}):
+   - [Block.Ext_attributes]: a djot attribute line attached to a block, a heading
+     included — the heading's own [`Id] mirrors it, see below.
    - [Inline.Ext_attributes]: [{#id}] attached to an inline span (column-precise).
-   - a heading carrying an explicitly-supplied [`Id], distinct from its slug.
 
    The [Ext_attributes] wrappers are visited by the top-level folder callback and
    then recursed into manually, so ids nested inside an attributed block/span are
@@ -132,10 +134,10 @@ let extract_attr_ids (doc : Cmarkit.Doc.t) : attr_entry list =
           let acc = add_attr acc (Cmarkit.Block.Attributes.attributes a) meta in
           Cmarkit.Folder.ret
             (Cmarkit.Folder.fold_block f acc (Cmarkit.Block.Attributes.block a))
-        | Cmarkit.Block.Heading (h, meta) ->
-          (match Cmarkit.Block.Heading.id h with
-           | Some (`Id id) -> Cmarkit.Folder.ret (add_id acc id meta)
-           | Some (`Auto _) | None -> Cmarkit.Folder.default)
+        (* A heading's [`Id] is not collected here: the parser resolves it from
+           the [ {#id} ] line above the heading, which is the [Ext_attributes]
+           wrapper visited above — collecting both would report the anchor twice,
+           and the attribute line is the better place to jump to. *)
         | _ -> Cmarkit.Folder.default)
       ~inline_ext_default:(fun _f acc _i -> acc)
       ~block_ext_default:(fun _f acc _b -> acc)
@@ -188,7 +190,7 @@ let%expect_test "extract_headings" =
     {|
     H1: Title [title]
     H2: Chapter 1 [chapter-1]
-    H3: Section 1.1 [section-1-1]
+    H3: Section 1.1 [section-11]
     H2: Chapter 2 [chapter-2]
     H4: Deep [deep]
     |}]

--- a/pkg/oystermark/lib/vault_graph/common.ml
+++ b/pkg/oystermark/lib/vault_graph/common.ml
@@ -327,7 +327,7 @@ let%test_module "graph" =
 
     let%expect_test "heading link" =
       let vault =
-        build_vault [ "a.md", "see [[b#Section]]"; "b.md", "# Section\nsome content" ]
+        build_vault [ "a.md", "see [[b#Section]]"; "b.md", "# Section\n\nsome content" ]
       in
       let g = of_vault vault in
       show_edges g;
@@ -349,7 +349,7 @@ let%test_module "graph" =
     ;;
 
     let%expect_test "self-links" =
-      let vault = build_vault [ "a.md", "# Top\nsee [[a]] and [[a#Top]]" ] in
+      let vault = build_vault [ "a.md", "# Top\n\nsee [[a]] and [[a#Top]]" ] in
       let g = of_vault vault in
       show_edges g;
       [%expect
@@ -359,7 +359,7 @@ let%test_module "graph" =
           ((path a.md)
            (kind
             (Link
-             ((first_byte 10) (last_byte 14) (first_line (2 6)) (last_line (2 6)))))))
+             ((first_byte 11) (last_byte 15) (first_line (3 7)) (last_line (3 7)))))))
          (Tgt ((path a.md) (kind Note))))
 
         1
@@ -367,7 +367,7 @@ let%test_module "graph" =
           ((path a.md)
            (kind
             (Link
-             ((first_byte 20) (last_byte 28) (first_line (2 6)) (last_line (2 6)))))))
+             ((first_byte 21) (last_byte 29) (first_line (3 7)) (last_line (3 7)))))))
          (Tgt
           ((path a.md)
            (kind

--- a/pkg/oystermark/lsp/CLAUDE.md
+++ b/pkg/oystermark/lsp/CLAUDE.md
@@ -9,6 +9,10 @@ Development of LSP is driven by specifications in docs/ dir.
   - Define module interface (`.mli` file and inline submodule) to explicitly control what should be exposed.
   - For testing utils, define it as `module For_test ...`
 - Property-based testing is encouraged. Trace-based testing is encouraged.
+- `main.ml` is the one file `dune runtest` cannot reach: it is the protocol
+  adapter, and the tests drive `Server` in process. A handler hung off the
+  wrong linol hook type-checks, passes every test, and is never called. After
+  changing it, run `scripts/smoke.py` (see README) against the built binary.
 
 Design
 - The LSP is expected to be a glue layer on top of the core functionlities. In the long term, we would like most of the core calculations provided by upstream (oystermark/lib).

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -66,6 +66,19 @@ logic of its own. Spec: [feature-attribute-anchors.mld](docs/feature-attribute-a
 | Inlay hints | Reference counts next to headings and at the top of the file. | [inlay-hints](docs/feature-inlay-hints.mld) |
 | Rename | Renames a note and rewrites the links pointing at it. | [rename](docs/feature-rename.mld) |
 | Code action | Creates the note behind an unresolved link. | [codeaction](docs/feature-codeaction-create-unresolved-link.mld) |
+| Daily notes | Open or create today's / yesterday's / tomorrow's note, and jump to the previous or next existing one. | [daily-notes](docs/feature-daily-notes.mld) |
+
+Daily notes are configured through the client's `initializationOptions`:
+
+```json
+{ "dailyNotes": { "format": "YYYY/MM/YYYY-MM-DD", "folder": "journal" } }
+```
+
+`format` is a subset of the [moment.js](https://momentjs.com/docs/#/displaying/format/)
+tokens and may contain `/` to nest notes in folders; `folder` defaults to the
+vault root. Obsidian's own `.obsidian/daily-notes.json` is not read — see
+[the reference spec](../../../specification/obsidian/daily-notes.md) for how
+Obsidian behaves.
 
 Positions are UTF-16 code units, per the LSP spec — see
 [feature-utf16-positions](docs/feature-utf16-positions.mld).

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -67,6 +67,7 @@ logic of its own. Spec: [feature-attribute-anchors.mld](docs/feature-attribute-a
 | Rename | Renames a note and rewrites the links pointing at it. | [rename](docs/feature-rename.mld) |
 | Code action | Creates the note behind an unresolved link. | [codeaction](docs/feature-codeaction-create-unresolved-link.mld) |
 | Daily notes | Open or create today's / yesterday's / tomorrow's note, and jump to the previous or next existing one. | [daily-notes](docs/feature-daily-notes.mld) |
+| Command block | A fenced `oysterlsp` block whose lines become clickable code lenses — a small control panel inside a note. | [command-block](docs/feature-command-block.mld) |
 
 ## Configuration
 

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -68,16 +68,29 @@ logic of its own. Spec: [feature-attribute-anchors.mld](docs/feature-attribute-a
 | Code action | Creates the note behind an unresolved link. | [codeaction](docs/feature-codeaction-create-unresolved-link.mld) |
 | Daily notes | Open or create today's / yesterday's / tomorrow's note, and jump to the previous or next existing one. | [daily-notes](docs/feature-daily-notes.mld) |
 
-Daily notes are configured through the client's `initializationOptions`:
+## Configuration
+
+Settings come from `oysterlsp.json` at the vault root, falling back to the
+client's `initializationOptions` key by key — full schema in
+[configuration](docs/feature-configuration.mld).
 
 ```json
-{ "dailyNotes": { "format": "YYYY/MM/YYYY-MM-DD", "folder": "journal" } }
+{
+  "dailyNotes": { "format": "YYYY/MM/YYYY-MM-DD", "folder": "journal" },
+  "hover": { "maxChars": 400 },
+  "goToDefinition": { "unresolvedFragment": "strict" },
+  "diagnostics": { "unresolvedFragment": "strict" }
+}
 ```
 
-`format` is a subset of the [moment.js](https://momentjs.com/docs/#/displaying/format/)
-tokens and may contain `/` to nest notes in folders; `folder` defaults to the
-vault root. A format the server cannot support disables the feature and is
-reported as a warning message at startup. Obsidian's own `.obsidian/daily-notes.json` is not read — see
+The daily-note `format` is a subset of the
+[moment.js](https://momentjs.com/docs/#/displaying/format/) tokens and may
+contain `/` to nest notes in folders; `folder` defaults to the vault root.
+
+Nothing here can stop the server from starting: a missing file, bad JSON, an
+unknown key or an unusable value falls back to the default. Every such fallback
+is reported as a warning message at startup, so an ignored setting is never
+silent. Obsidian's own `.obsidian/daily-notes.json` is not read — see
 [the reference spec](../../../specification/obsidian/daily-notes.md) for how
 Obsidian behaves.
 

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -1,0 +1,71 @@
+# oystermark-lsp
+
+Language server for Oystermark vaults.
+
+## Markdown flavor
+
+We use: CommonMark + Github-flavored extensions + Obsidian extensions + djot non-restrictive extensions + our own extensions (struct, etc.)
+
+Extensions are additive. Djot syntax is borrowed as extensions while its
+restrictions are not adopted: where djot removes something from Markdown
+(indented code blocks, setext headings, CommonMark emphasis flanking, `___`
+thematic breaks), the CommonMark behavior is kept.
+
+## Anchors
+
+A `#fragment` is matched against one namespace, in this order; first match wins:
+
+| # | Kind | Written as | Referenced by | Granularity |
+|---|---|---|---|---|
+| 1 | Heading | `# My Heading` | `[[note#My Heading]]` (heading **text**, not slug) | line |
+| 2 | Caret block id | `text ^blk1` | `[[note#^blk1]]` | block |
+| 3 | Attribute id | `{#id}` / `[text]{#id}` | `[[note#id]]` | block, or **inline span** |
+
+Attribute ids are author-controlled and stable, and are the only kind that can
+pin an arbitrary inline span:
+
+```markdown
+{#custom-h}
+# My Heading
+
+The [key term]{#kt} is defined here.
+
+{#aside}
+> An aside worth linking to.
+```
+
+```markdown
+See [[my-note#kt]] and [[my-note#aside]]; within the note, [[#My Heading]].
+A CommonMark link reaches the same anchors: [the key term](#kt), [aside](#aside).
+```
+
+Both link syntaxes reach all three anchor kinds — nothing in resolution is
+specific to wikilinks, and nothing is specific to headings. The full 2×3 matrix
+is pinned by the expect test *"intra-note: {wikilink, markdown link} x
+{heading, block attribute, inline attribute}"* in
+[go_to_definition.ml](go_to_definition.ml).
+
+Note: an explicit `{#id}` on a heading *replaces* its generated identifier. The
+heading is still reachable by its text (`[[note#My Heading]]`), but not by the
+derived slug.
+
+Anchors are collected and resolved in the core (`lib/vault/index.ml`,
+`lib/vault/resolve.ml`); the LSP consumes resolved targets and adds no anchor
+logic of its own. Spec: [feature-attribute-anchors.mld](docs/feature-attribute-anchors.mld).
+
+## Features
+
+| Feature | Behavior | Spec |
+|---|---|---|
+| Go to definition | Jumps to a link's target. Inline attribute anchors resolve to line *and* character. | [go-to-definition](docs/feature-go-to-definition.mld) |
+| Find references | From a link or an anchor, lists every link resolving to the same target. | [find-references](docs/feature-find-references.mld) |
+| Completion | Note names after `[[`; heading texts, block ids and attribute ids after `#`. | [completion](docs/feature-completion.mld) |
+| Diagnostics | Unresolved links and fragments; duplicate ids in one file. | [diagnostics](docs/feature-diagnostics.mld) |
+| Hover | Preview of the target note or section. | [hover](docs/feature-hover.mld) |
+| Document outline | Headings and struct keys as a symbol tree. | [document-outline](docs/feature-document-outline.mld) |
+| Inlay hints | Reference counts next to headings and at the top of the file. | [inlay-hints](docs/feature-inlay-hints.mld) |
+| Rename | Renames a note and rewrites the links pointing at it. | [rename](docs/feature-rename.mld) |
+| Code action | Creates the note behind an unresolved link. | [codeaction](docs/feature-codeaction-create-unresolved-link.mld) |
+
+Positions are UTF-16 code units, per the LSP spec — see
+[feature-utf16-positions](docs/feature-utf16-positions.mld).

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -99,14 +99,33 @@ Settings come from `oysterlsp.json` at the vault root, falling back to the
 client's `initializationOptions` key by key — full schema in
 [configuration](docs/feature-configuration.mld).
 
+For a starting file with every key at its default:
+
+```bash
+oystermark-lsp --print-default-config > oysterlsp.json
+```
+
+It includes a `"$schema"` line pointing at the raw
+[oysterlsp.schema.json](oysterlsp.schema.json) on `main`, which any JSON
+language server picks up — that is where key completion, value validation and per-key
+documentation come from, so prefer it over memorizing the table.
+
 ```json
 {
-  "dailyNotes": { "format": "YYYY/MM/YYYY-MM-DD", "folder": "journal" },
+  "dailyNotes": {
+    "format": "YYYY/MM/YYYY-MM-DD",
+    "folder": "journal",
+    "linkAction": false
+  },
   "hover": { "maxChars": 400 },
   "goToDefinition": { "unresolvedFragment": "strict" },
   "diagnostics": { "unresolvedFragment": "strict" }
 }
 ```
+
+`linkAction` (default `true`) governs the one daily-note action offered in
+every menu — *Insert link to today's daily note* — so it can be withdrawn
+without disabling daily notes.
 
 The daily-note `format` is a subset of the
 [moment.js](https://momentjs.com/docs/#/displaying/format/) tokens and may

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -76,7 +76,8 @@ Daily notes are configured through the client's `initializationOptions`:
 
 `format` is a subset of the [moment.js](https://momentjs.com/docs/#/displaying/format/)
 tokens and may contain `/` to nest notes in folders; `folder` defaults to the
-vault root. Obsidian's own `.obsidian/daily-notes.json` is not read — see
+vault root. A format the server cannot support disables the feature and is
+reported as a warning message at startup. Obsidian's own `.obsidian/daily-notes.json` is not read — see
 [the reference spec](../../../specification/obsidian/daily-notes.md) for how
 Obsidian behaves.
 

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -11,6 +11,19 @@ restrictions are not adopted: where djot removes something from Markdown
 (indented code blocks, setext headings, CommonMark emphasis flanking, `___`
 thematic breaks), the CommonMark behavior is kept.
 
+One addition changes the meaning of text that was already valid CommonMark, so
+it is worth stating on its own: **a heading runs to the next blank line**, djot
+style, rather than ending at its own line.
+
+```markdown
+# Section
+some content
+```
+
+is one heading titled `Section some content`, not a heading followed by a
+paragraph — so `[[note#Section]]` does not find it. Leave a blank line under a
+heading.
+
 ## Anchors
 
 A `#fragment` is matched against one namespace, in this order; first match wins:

--- a/pkg/oystermark/lsp/README.md
+++ b/pkg/oystermark/lsp/README.md
@@ -69,6 +69,30 @@ logic of its own. Spec: [feature-attribute-anchors.mld](docs/feature-attribute-a
 | Daily notes | Open or create today's / yesterday's / tomorrow's note, and jump to the previous or next existing one. | [daily-notes](docs/feature-daily-notes.mld) |
 | Command block | A fenced `oysterlsp` block whose lines become clickable code lenses — a small control panel inside a note. | [command-block](docs/feature-command-block.mld) |
 
+## Adapter smoke check
+
+`tests/lsp/` drives `Lsp_lib.Server` in process, so `main.ml` — capability
+advertisement and request dispatch — is not covered by `dune runtest`. The gap
+is not theoretical: `workspace/executeCommand` was once answered from
+`on_request_unhandled`, which linol never consults for `ExecuteCommand`, so the
+daily-note command silently returned `null` in every client while the suite
+stayed green.
+
+After changing `main.ml`, run the session-level check by hand:
+
+```bash
+dune build pkg/oystermark/lsp/main.exe
+uv run --no-project pkg/oystermark/lsp/scripts/smoke.py
+```
+
+It opens a real stdio session against a bare vault (no `oysterlsp.json`, no
+`initializationOptions`) and asserts the effects an editor observes: the
+advertised capabilities, the code actions offered, that a command reaches its
+handler and produces `workspace/applyEdit` plus `window/showDocument`, and that
+a command-block line gets a lens carrying a command. Pass a path to check
+another binary — `… scripts/smoke.py $(which oystermark-lsp)` verifies what is
+installed, which is what your editor actually runs.
+
 ## Configuration
 
 Settings come from `oysterlsp.json` at the vault root, falling back to the

--- a/pkg/oystermark/lsp/command_block.ml
+++ b/pkg/oystermark/lsp/command_block.ml
@@ -75,13 +75,17 @@ let is_ignorable (text : string) : bool =
   String.is_empty text || String.is_prefix text ~prefix:"#"
 ;;
 
-(** Every line of every command block in [content], blanks and comments
-    included, as [(line, stripped text)].
+(** Fold [f] over every command block in [content], in document order.
 
-    Lines are located through the parser rather than by scanning for fences:
+    Blocks are located through the parser rather than by scanning for fences:
     indented, nested and differently-fenced blocks are the parser's problem,
     and it has already solved them. *)
-let block_lines (content : string) : (int * string) list =
+let fold_command_blocks
+      (content : string)
+      ~(init : 'a)
+      ~(f : 'a -> Cmarkit.Block.Code_block.t -> 'a)
+  : 'a
+  =
   let doc = Lsp_util.parse_doc content in
   let folder =
     Cmarkit.Folder.make
@@ -95,13 +99,7 @@ let block_lines (content : string) : (int * string) list =
           in
           if not (is_command_block info)
           then Cmarkit.Folder.default
-          else
-            Cmarkit.Folder.ret
-              (List.fold (Cmarkit.Block.Code_block.code cb) ~init:acc ~f:(fun acc bl ->
-                 let line, _character =
-                   Lsp_util.position_of_textloc ~content (Cmarkit.Meta.textloc (snd bl))
-                 in
-                 (line, String.strip (Cmarkit.Block_line.to_string bl)) :: acc))
+          else Cmarkit.Folder.ret (f acc cb)
         | _ -> Cmarkit.Folder.default)
         (* Inlines cannot contain a code block, so skip them wholesale rather
          than teach the folder every inline extension Oystermark adds. *)
@@ -114,7 +112,26 @@ let block_lines (content : string) : (int * string) list =
       ~block_ext_default:(fun _folder acc _b -> acc)
       ()
   in
-  List.rev (Cmarkit.Folder.fold_doc folder [] doc)
+  Cmarkit.Folder.fold_doc folder init doc
+;;
+
+(** Every line of every command block in [content], blanks and comments
+    included, as [(line, stripped text)]. *)
+let block_lines (content : string) : (int * string) list =
+  List.rev
+    (fold_command_blocks content ~init:[] ~f:(fun acc cb ->
+       List.fold (Cmarkit.Block.Code_block.code cb) ~init:acc ~f:(fun acc bl ->
+         let line, _character =
+           Lsp_util.position_of_textloc ~content (Cmarkit.Meta.textloc (snd bl))
+         in
+         (line, String.strip (Cmarkit.Block_line.to_string bl)) :: acc)))
+;;
+
+(** Whether [content] already holds a block.  Asked before offering to insert
+    one; not [block_lines], which cannot tell an empty block from no block.
+    See {!page-"feature-command-block".insert}. *)
+let has_command_block (content : string) : bool =
+  fold_command_blocks content ~init:false ~f:(fun _acc _cb -> true)
 ;;
 
 (** [entries content] is every meaningful line of every command block, in
@@ -139,6 +156,19 @@ let entry_at (content : string) ~(line : int) : entry option =
     typed, and {!entries} skips those. *)
 let in_command_block (content : string) ~(line : int) : bool =
   List.exists (block_lines content) ~f:(fun (l, _) -> Int.equal l line)
+;;
+
+(** {1:render Writing a block}
+
+    The inverse of {!entries}, used by the action that seeds a note with a
+    panel.  See {!page-"feature-command-block".insert}. *)
+
+(** A fresh block listing [commands], one per line, fences included.  Ends in a
+    blank line so that whatever the insertion point pushed down stays a
+    paragraph of its own. *)
+let render (commands : command list) : string =
+  String.concat ~sep:"\n" (("```" ^ info_string) :: List.map commands ~f:name_of_command)
+  ^ "\n```\n\n"
 ;;
 
 (** {1:test Test} *)
@@ -270,6 +300,48 @@ prose
         1: entry=daily/today in_block=true
         2: entry=- in_block=true
         4: entry=- in_block=false
+        |}]
+    ;;
+
+    (* An empty block is a block: the insert action must not offer to add a
+       second one just because the first holds no lines yet. *)
+    let%expect_test "has_command_block" =
+      let check content = printf "%b\n" (has_command_block content) in
+      check "```oysterlsp\ndaily/today\n```\n";
+      check "```oysterlsp\n```\n";
+      check "```ocaml\ndaily/today\n```\n";
+      check "# prose only\n";
+      [%expect
+        {|
+        true
+        true
+        false
+        false
+        |}]
+    ;;
+
+    let%expect_test "render" =
+      print_string (render [ Daily_today; Daily_prev ]);
+      [%expect
+        {|
+        ```oysterlsp
+        daily/today
+        daily/prev
+        ```
+        |}]
+    ;;
+
+    (* What is written can be read back: rendering then parsing recovers the
+       commands, at the lines the block put them on. *)
+    let%expect_test "render round-trips through entries" =
+      show (render all_of_command);
+      [%expect
+        {|
+        1 daily/today        daily/today
+        2 daily/yesterday    daily/yesterday
+        3 daily/tomorrow     daily/tomorrow
+        4 daily/prev         daily/prev
+        5 daily/next         daily/next
         |}]
     ;;
 

--- a/pkg/oystermark/lsp/command_block.ml
+++ b/pkg/oystermark/lsp/command_block.ml
@@ -1,0 +1,289 @@
+(** Command blocks: fenced [oysterlsp] blocks whose lines name server
+    commands.
+
+    Spec: {!page-"feature-command-block"}.
+
+    The pure layer — finding the blocks and reading their lines. What a command
+    {e does} lives in {!Server}; this module only says which line asked for
+    which one, so the surfaces built on it (lens, action, completion,
+    diagnostic) all agree about what is where. *)
+
+open Core
+
+(** {1:catalogue Catalogue}
+
+    The closed set of names a line may hold.  See
+    {!page-"feature-command-block".commands}. *)
+
+type command =
+  | Daily_today
+  | Daily_yesterday
+  | Daily_tomorrow
+  | Daily_prev
+  | Daily_next
+[@@deriving sexp, equal, compare, enumerate]
+
+let name_of_command : command -> string = function
+  | Daily_today -> "daily/today"
+  | Daily_yesterday -> "daily/yesterday"
+  | Daily_tomorrow -> "daily/tomorrow"
+  | Daily_prev -> "daily/prev"
+  | Daily_next -> "daily/next"
+;;
+
+(** What the command is for, one line, shown while completing.  Deliberately
+    not the lens title: that one reports what will {e happen} to this vault
+    today ("Create yesterday's daily note"), which only {!Server} knows. *)
+let doc_of_command : command -> string = function
+  | Daily_today -> "Open today's daily note, creating it when missing"
+  | Daily_yesterday -> "Open yesterday's daily note, creating it when missing"
+  | Daily_tomorrow -> "Open tomorrow's daily note, creating it when missing"
+  | Daily_prev -> "Open the previous existing daily note, relative to this note"
+  | Daily_next -> "Open the next existing daily note, relative to this note"
+;;
+
+let command_of_name (s : string) : command option =
+  List.find all_of_command ~f:(fun c -> String.equal (name_of_command c) s)
+;;
+
+(** {1:reading Reading a block}
+
+    A line is exactly its command name: fenced content is literal text, not
+    markdown.  See {!page-"feature-command-block".syntax}. *)
+
+(** One meaningful line of a command block. *)
+type entry =
+  { line : int (** 0-based, as LSP counts. *)
+  ; text : string (** The line, stripped. *)
+  ; command : command option (** [None] when the name is unknown. *)
+  }
+[@@deriving sexp_of, equal, compare]
+
+let info_string = "oysterlsp"
+
+(** Whether a code block's info string opens a command block.  Only the first
+    word is considered, so [oysterlsp \{#id\}] — the attribute syntax any code
+    block may carry — still counts.  See {!Oystermark.Parse.Cb_attribute}. *)
+let is_command_block (info : string) : bool =
+  match String.split (String.strip info) ~on:' ' with
+  | first :: _ -> String.equal first info_string
+  | [] -> false
+;;
+
+(** Blank, or a comment: not a command, and not an error either. *)
+let is_ignorable (text : string) : bool =
+  String.is_empty text || String.is_prefix text ~prefix:"#"
+;;
+
+(** Every line of every command block in [content], blanks and comments
+    included, as [(line, stripped text)].
+
+    Lines are located through the parser rather than by scanning for fences:
+    indented, nested and differently-fenced blocks are the parser's problem,
+    and it has already solved them. *)
+let block_lines (content : string) : (int * string) list =
+  let doc = Lsp_util.parse_doc content in
+  let folder =
+    Cmarkit.Folder.make
+      ~block:(fun _folder acc (b : Cmarkit.Block.t) ->
+        match b with
+        | Cmarkit.Block.Code_block (cb, _meta) ->
+          let info =
+            match Cmarkit.Block.Code_block.info_string cb with
+            | Some (info, _) -> info
+            | None -> ""
+          in
+          if not (is_command_block info)
+          then Cmarkit.Folder.default
+          else
+            Cmarkit.Folder.ret
+              (List.fold (Cmarkit.Block.Code_block.code cb) ~init:acc ~f:(fun acc bl ->
+                 let line, _character =
+                   Lsp_util.position_of_textloc ~content (Cmarkit.Meta.textloc (snd bl))
+                 in
+                 (line, String.strip (Cmarkit.Block_line.to_string bl)) :: acc))
+        | _ -> Cmarkit.Folder.default)
+        (* Inlines cannot contain a code block, so skip them wholesale rather
+         than teach the folder every inline extension Oystermark adds. *)
+      ~inline:(fun _folder acc _i -> Cmarkit.Folder.ret acc)
+      ~inline_ext_default:(fun _folder acc _i -> acc)
+        (* Reached only for AST extensions the folder does not already know —
+         it knows callouts, divs and tables, and descends into them. Returning
+         the accumulator keeps an unknown future extension from raising, at
+         the cost of not seeing blocks nested inside it. *)
+      ~block_ext_default:(fun _folder acc _b -> acc)
+      ()
+  in
+  List.rev (Cmarkit.Folder.fold_doc folder [] doc)
+;;
+
+(** [entries content] is every meaningful line of every command block, in
+    document order. *)
+let entries (content : string) : entry list =
+  block_lines content
+  |> List.filter_map ~f:(fun (line, text) ->
+    if is_ignorable text
+    then None
+    else Some { line; text; command = command_of_name text })
+;;
+
+(** [entry_at content ~line] is the command-block line the cursor sits on, if
+    any.  Used by the code-action surface, which is anchored to a position
+    rather than to the whole document. *)
+let entry_at (content : string) ~(line : int) : entry option =
+  List.find (entries content) ~f:(fun e -> Int.equal e.line line)
+;;
+
+(** Whether [line] falls inside a command block, meaningful or not.  Completion
+    asks this: a blank line in a block is exactly where a name is about to be
+    typed, and {!entries} skips those. *)
+let in_command_block (content : string) ~(line : int) : bool =
+  List.exists (block_lines content) ~f:(fun (l, _) -> Int.equal l line)
+;;
+
+(** {1:test Test} *)
+
+let%test_module "command_block" =
+  (module struct
+    let show (content : string) =
+      List.iter (entries content) ~f:(fun e ->
+        printf
+          "%d %-18s %s\n"
+          e.line
+          e.text
+          (match e.command with
+           | Some c -> name_of_command c
+           | None -> "<unknown>"))
+    ;;
+
+    let%expect_test "a block's lines, with their positions" =
+      show
+        {|# Journal
+
+```oysterlsp
+daily/today
+daily/prev
+```
+
+Some prose.
+|};
+      [%expect
+        {|
+        3 daily/today        daily/today
+        4 daily/prev         daily/prev
+        |}]
+    ;;
+
+    (* Blank lines and comments are structure, not mistakes; an unrecognized
+       name is a mistake, and is kept so a diagnostic can point at it. *)
+    let%expect_test "blanks, comments, and unknown names" =
+      show
+        {|```oysterlsp
+# navigation
+
+daily/today
+  daily/next
+daily/yesterdya
+```
+|};
+      [%expect
+        {|
+        3 daily/today        daily/today
+        4 daily/next         daily/next
+        5 daily/yesterdya    <unknown>
+        |}]
+    ;;
+
+    let%expect_test "several blocks, and blocks that are not ours" =
+      show
+        {|```oysterlsp
+daily/today
+```
+
+```ocaml
+daily/today
+```
+
+```oysterlsp {#panel}
+daily/next
+```
+|};
+      [%expect
+        {|
+        1 daily/today        daily/today
+        9 daily/next         daily/next
+        |}]
+    ;;
+
+    (* An indented block is still a block; scanning for fences by hand would
+       have to know that. *)
+    let%expect_test "inside a list item" =
+      show
+        {|- a list item:
+
+  ```oysterlsp
+  daily/today
+  ```
+|};
+      [%expect {| 3 daily/today        daily/today |}]
+    ;;
+
+    (* Container extensions are the parser's business, and it descends into
+       them: a panel inside a callout is found like any other. *)
+    let%expect_test "inside a callout" =
+      show
+        {|> [!note]
+> ```oysterlsp
+> daily/today
+> ```
+|};
+      [%expect {| 2 daily/today        daily/today |}]
+    ;;
+
+    let%expect_test "no block at all" =
+      show "# Just a note\n\nwith prose.\n";
+      [%expect {| |}]
+    ;;
+
+    let%expect_test "entry_at and in_command_block" =
+      let content =
+        {|```oysterlsp
+daily/today
+
+```
+prose
+|}
+      in
+      let at line =
+        printf
+          "%d: entry=%s in_block=%b\n"
+          line
+          (match entry_at content ~line with
+           | Some e -> e.text
+           | None -> "-")
+          (in_command_block content ~line)
+      in
+      List.iter [ 0; 1; 2; 4 ] ~f:at;
+      [%expect
+        {|
+        0: entry=- in_block=false
+        1: entry=daily/today in_block=true
+        2: entry=- in_block=true
+        4: entry=- in_block=false
+        |}]
+    ;;
+
+    let%expect_test "catalogue" =
+      List.iter all_of_command ~f:(fun c ->
+        printf "%-16s %s\n" (name_of_command c) (doc_of_command c));
+      [%expect
+        {|
+        daily/today      Open today's daily note, creating it when missing
+        daily/yesterday  Open yesterday's daily note, creating it when missing
+        daily/tomorrow   Open tomorrow's daily note, creating it when missing
+        daily/prev       Open the previous existing daily note, relative to this note
+        daily/next       Open the next existing daily note, relative to this note
+        |}]
+    ;;
+  end)
+;;

--- a/pkg/oystermark/lsp/daily_notes.ml
+++ b/pkg/oystermark/lsp/daily_notes.ml
@@ -1,0 +1,500 @@
+(** Daily notes: date formats, path computation, and recognition.
+
+    The pure layer of {!page-"feature-daily-notes"}: everything here is a
+    function of a settings record and a date. Nothing reads the clock — "today"
+    is always passed in — so results are deterministic and testable.
+
+    Spec: {!page-"feature-daily-notes"}. *)
+
+open Core
+
+(** {1:format Date format}
+
+    A subset of the moment.js tokens, per
+    {!page-"feature-daily-notes".format}. *)
+
+module Format = struct
+  (** One element of a parsed format string. *)
+  type piece =
+    | Year4 (** [YYYY] *)
+    | Year2 (** [YY] *)
+    | Month2 (** [MM] *)
+    | Month (** [M] *)
+    | Month_abbr (** [MMM] *)
+    | Month_name (** [MMMM] *)
+    | Day2 (** [DD] *)
+    | Day (** [D] *)
+    | Day_ordinal (** [Do] *)
+    | Weekday_abbr (** [ddd] *)
+    | Weekday_name (** [dddd] *)
+    | Literal of string
+  [@@deriving sexp_of]
+
+  type t =
+    { pieces : piece list
+    ; source : string (** The format as written, for round-tripping settings. *)
+    }
+  [@@deriving sexp_of]
+
+  (** Recognized tokens, longest first so that [MMMM] is not read as [MMM]
+      followed by a stray [M]. *)
+  let tokens =
+    [ "MMMM", Month_name
+    ; "dddd", Weekday_name
+    ; "YYYY", Year4
+    ; "MMM", Month_abbr
+    ; "ddd", Weekday_abbr
+    ; "YY", Year2
+    ; "MM", Month2
+    ; "DD", Day2
+    ; "Do", Day_ordinal
+    ; "M", Month
+    ; "D", Day
+    ]
+  ;;
+
+  (* Characters a path component may not contain.  ['/'] is absent on purpose:
+     a format may nest the note in folders.  Mirrors the validation Obsidian's
+     settings tab applies. *)
+  let illegal_chars = [ '*'; '"'; '\\'; '<'; '>'; ':'; '|'; '?' ]
+
+  let matches_token (s : string) ~(pos : int) : (string * piece) option =
+    List.find tokens ~f:(fun (tok, _) ->
+      String.length tok <= String.length s - pos
+      && String.equal tok (String.sub s ~pos ~len:(String.length tok)))
+  ;;
+
+  (** Split [s] into pieces.  Errors on an unsupported alphabetic token rather
+      than treating it as a literal: silently naming the wrong file is the one
+      outcome worth failing over. *)
+  let parse_pieces (s : string) : (piece list, string) Result.t =
+    let len = String.length s in
+    let rec loop pos acc =
+      if pos >= len
+      then Ok (List.rev acc)
+      else (
+        match s.[pos] with
+        (* [ ... ] is literal text. *)
+        | '[' ->
+          (match String.index_from s pos ']' with
+           | None -> Error "unterminated [ in format"
+           | Some close ->
+             let text = String.sub s ~pos:(pos + 1) ~len:(close - pos - 1) in
+             loop (close + 1) (Literal text :: acc))
+        | c ->
+          (match matches_token s ~pos with
+           | Some (tok, piece) -> loop (pos + String.length tok) (piece :: acc)
+           | None ->
+             if Char.is_alpha c
+             then Error (sprintf "unsupported format token %C" c)
+             else loop (pos + 1) (Literal (String.of_char c) :: acc)))
+    in
+    loop 0 []
+  ;;
+
+  let month_names =
+    [| "January"
+     ; "February"
+     ; "March"
+     ; "April"
+     ; "May"
+     ; "June"
+     ; "July"
+     ; "August"
+     ; "September"
+     ; "October"
+     ; "November"
+     ; "December"
+    |]
+  ;;
+
+  let weekday_names =
+    [| "Sunday"; "Monday"; "Tuesday"; "Wednesday"; "Thursday"; "Friday"; "Saturday" |]
+  ;;
+
+  (** English ordinal suffix: [1st], [2nd], [3rd], [4th], and the [11th]–[13th]
+      exception. *)
+  let ordinal (n : int) : string =
+    let suffix =
+      if n % 100 >= 11 && n % 100 <= 13
+      then "th"
+      else (
+        match n % 10 with
+        | 1 -> "st"
+        | 2 -> "nd"
+        | 3 -> "rd"
+        | _ -> "th")
+    in
+    Int.to_string n ^ suffix
+  ;;
+
+  let render_piece (piece : piece) (date : Date.t) : string =
+    let month = Month.to_int (Date.month date) in
+    let day = Date.day date in
+    let year = Date.year date in
+    match piece with
+    | Year4 -> sprintf "%04d" year
+    | Year2 -> sprintf "%02d" (year % 100)
+    | Month2 -> sprintf "%02d" month
+    | Month -> Int.to_string month
+    | Month_abbr -> String.sub month_names.(month - 1) ~pos:0 ~len:3
+    | Month_name -> month_names.(month - 1)
+    | Day2 -> sprintf "%02d" day
+    | Day -> Int.to_string day
+    | Day_ordinal -> ordinal day
+    | Weekday_abbr ->
+      String.sub weekday_names.(Day_of_week.to_int (Date.day_of_week date)) ~pos:0 ~len:3
+    | Weekday_name -> weekday_names.(Day_of_week.to_int (Date.day_of_week date))
+    | Literal s -> s
+  ;;
+
+  let render_pieces (pieces : piece list) (date : Date.t) : string =
+    String.concat (List.map pieces ~f:(fun p -> render_piece p date))
+  ;;
+
+  (** A reference date used to check what a format produces.  Every field
+      differs from every other, so a rendering mistake shows up as a wrong
+      component rather than a coincidence. *)
+  let probe_date = Date.create_exn ~y:2026 ~m:Month.Jul ~d:6
+
+  (** [of_string s] validates [s] as a daily-note format.  Rejects, per
+      {!page-"feature-daily-notes".format}: unsupported tokens, a leading [/],
+      an empty result, and text illegal in a path. *)
+  let of_string (s : string) : (t, string) Result.t =
+    if String.is_prefix s ~prefix:"/"
+    then Error "format must not start with /"
+    else (
+      match parse_pieces s with
+      | Error _ as e -> e
+      | Ok pieces ->
+        let rendered = String.strip (render_pieces pieces probe_date) in
+        if String.is_empty rendered
+        then Error "format produces an empty name"
+        else (
+          match
+            String.find rendered ~f:(fun c -> List.mem illegal_chars c ~equal:Char.equal)
+          with
+          | Some c -> Error (sprintf "format produces %C, illegal in a path" c)
+          | None -> Ok { pieces; source = s }))
+  ;;
+
+  let to_string (t : t) : string = t.source
+
+  (** The note name for [date] — the path without the [.md] suffix.  Trimmed,
+      as Obsidian trims. *)
+  let render (t : t) (date : Date.t) : string = String.strip (render_pieces t.pieces date)
+end
+
+(** {1 Settings}
+
+    See {!page-"feature-daily-notes"}. Sourced from LSP
+    [initializationOptions]; this module only consumes the resolved record. *)
+
+type settings =
+  { format : Format.t
+  ; folder : string option (** [None] is the vault root. *)
+  ; template : string option
+    (** Carried but unused: template support is stubbed, per
+        {!page-"feature-daily-notes".limitations}. *)
+  }
+
+let default_format = Format.of_string "YYYY-MM-DD" |> Result.ok_or_failwith
+let default_settings = { format = default_format; folder = None; template = None }
+
+(** [path_of_date settings date] is the vault-relative path of [date]'s note.
+    The format may contain [/], so the result may name folders that do not
+    exist yet. *)
+let path_of_date (settings : settings) (date : Date.t) : string =
+  let name = Format.render settings.format date ^ ".md" in
+  match settings.folder with
+  | None | Some "" -> name
+  | Some folder -> Filename.concat (String.rstrip folder ~drop:(Char.equal '/')) name
+;;
+
+(** {1:recognition Recognition}
+
+    Path-to-date is the inverse of {!path_of_date}, obtained by generating
+    every date in a window and tabulating what it renders to, rather than by
+    parsing.  The table cannot disagree with the formatter — which a
+    hand-written strict parser could.  See
+    {!page-"feature-daily-notes".recognition}. *)
+
+module Table = struct
+  type t =
+    { by_path : Date.t String.Table.t
+    ; dates : Date.t array (** Ascending; the window, for prev/next scans. *)
+    ; settings : settings
+    }
+
+  let default_window_years = 5
+
+  (** [create settings ~today] tabulates [today ± window_years].  When a format
+      lacks a day token, several dates render to one path; the earliest wins,
+      which keeps recognition deterministic. *)
+  let create
+        ?(window_years = default_window_years)
+        (settings : settings)
+        ~(today : Date.t)
+    : t
+    =
+    let first = Date.add_years today (-window_years) in
+    let last = Date.add_years today window_years in
+    let dates =
+      let rec loop d acc =
+        if Date.(d > last) then acc else loop (Date.add_days d 1) (d :: acc)
+      in
+      loop first [] |> List.rev |> Array.of_list
+    in
+    let by_path = String.Table.create () in
+    Array.iter dates ~f:(fun d ->
+      let path = path_of_date settings d in
+      match Hashtbl.find by_path path with
+      | Some _ -> ()
+      | None -> Hashtbl.set by_path ~key:path ~data:d);
+    { by_path; dates; settings }
+  ;;
+
+  (** [date_of_path t path] is the date [path] names, or [None] when it is not
+      a daily note.  A note dated outside the window is not recognized; see
+      {!page-"feature-daily-notes".recognition}. *)
+  let date_of_path (t : t) (path : string) : Date.t option = Hashtbl.find t.by_path path
+
+  let is_daily_note (t : t) (path : string) : bool = Option.is_some (date_of_path t path)
+
+  (** [previous_existing t ~exists date] is the latest daily note strictly
+      before [date] whose file exists, with its path.  Never creates anything —
+      this is Obsidian's [daily-notes:goto-prev]. *)
+  let previous_existing (t : t) ~(exists : string -> bool) (date : Date.t)
+    : (Date.t * string) option
+    =
+    Array.fold_until
+      t.dates
+      ~init:None
+      ~f:(fun acc d ->
+        if Date.(d >= date)
+        then Stop acc
+        else (
+          let path = path_of_date t.settings d in
+          if exists path then Continue (Some (d, path)) else Continue acc))
+      ~finish:Fn.id
+  ;;
+
+  (** [next_existing t ~exists date] is the earliest daily note strictly after
+      [date] whose file exists. *)
+  let next_existing (t : t) ~(exists : string -> bool) (date : Date.t)
+    : (Date.t * string) option
+    =
+    Array.find_map t.dates ~f:(fun d ->
+      if Date.(d <= date)
+      then None
+      else (
+        let path = path_of_date t.settings d in
+        if exists path then Some (d, path) else None))
+  ;;
+end
+
+(** {1:test Test} *)
+
+let%test_module "daily_notes" =
+  (module struct
+    let fmt_exn s = Format.of_string s |> Result.ok_or_failwith
+    let date y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+    (** {2 Formatting}
+
+        See {!page-"feature-daily-notes".format}. *)
+
+    let%expect_test "supported tokens" =
+      let d = date 2026 7 6 in
+      List.iter
+        [ "YYYY-MM-DD"
+        ; "YYYY/MM/YYYY-MM-DD"
+        ; "YY-M-D"
+        ; "MMMM D, YYYY"
+        ; "MMM D"
+        ; "dddd"
+        ; "ddd"
+        ; "Do MMMM YYYY"
+        ; "[Daily] YYYY-MM-DD"
+        ; "YYYY-MM-DD [note]"
+        ]
+        ~f:(fun f -> printf "%-22s -> %s\n" f (Format.render (fmt_exn f) d));
+      [%expect
+        {|
+        YYYY-MM-DD             -> 2026-07-06
+        YYYY/MM/YYYY-MM-DD     -> 2026/07/2026-07-06
+        YY-M-D                 -> 26-7-6
+        MMMM D, YYYY           -> July 6, 2026
+        MMM D                  -> Jul 6
+        dddd                   -> Monday
+        ddd                    -> Mon
+        Do MMMM YYYY           -> 6th July 2026
+        [Daily] YYYY-MM-DD     -> Daily 2026-07-06
+        YYYY-MM-DD [note]      -> 2026-07-06 note
+        |}]
+    ;;
+
+    let%expect_test "ordinals" =
+      List.iter [ 1; 2; 3; 4; 11; 12; 13; 21; 22; 23; 31 ] ~f:(fun n ->
+        printf "%s " (Format.ordinal n));
+      [%expect {| 1st 2nd 3rd 4th 11th 12th 13th 21st 22nd 23rd 31st |}]
+    ;;
+
+    (** {2 Rejection}
+
+        An unsupported format disables the feature rather than naming a wrong
+        file. *)
+
+    let%expect_test "rejected formats" =
+      List.iter
+        [ "YYYY-ww" (* week token: does not identify a day *)
+        ; "YYYY-MM-DD HH:mm" (* time tokens, and [:] is path-illegal *)
+        ; "/YYYY-MM-DD"
+        ; "YYYY[-MM-DD"
+        ; "gggg"
+        ]
+        ~f:(fun f ->
+          match Format.of_string f with
+          | Ok _ -> printf "%-18s -> accepted\n" f
+          | Error e -> printf "%-18s -> rejected: %s\n" f e);
+      [%expect
+        {|
+        YYYY-ww            -> rejected: unsupported format token 'w'
+        YYYY-MM-DD HH:mm   -> rejected: unsupported format token 'H'
+        /YYYY-MM-DD        -> rejected: format must not start with /
+        YYYY[-MM-DD        -> rejected: unterminated [ in format
+        gggg               -> rejected: unsupported format token 'g'
+        |}]
+    ;;
+
+    (** {2 Paths} *)
+
+    let%expect_test "path_of_date" =
+      let d = date 2026 7 6 in
+      let show ?folder f =
+        let s = { default_settings with format = fmt_exn f; folder } in
+        printf
+          "%-20s folder=%-8s -> %s\n"
+          f
+          (Option.value folder ~default:"-")
+          (path_of_date s d)
+      in
+      show "YYYY-MM-DD";
+      show "YYYY-MM-DD" ~folder:"journal";
+      show "YYYY-MM-DD" ~folder:"journal/";
+      show "YYYY/MM/YYYY-MM-DD" ~folder:"journal";
+      show "MMMM D, YYYY" ~folder:"journal/daily";
+      [%expect
+        {|
+        YYYY-MM-DD           folder=-        -> 2026-07-06.md
+        YYYY-MM-DD           folder=journal  -> journal/2026-07-06.md
+        YYYY-MM-DD           folder=journal/ -> journal/2026-07-06.md
+        YYYY/MM/YYYY-MM-DD   folder=journal  -> journal/2026/07/2026-07-06.md
+        MMMM D, YYYY         folder=journal/daily -> journal/daily/July 6, 2026.md
+        |}]
+    ;;
+
+    (** {2 Recognition}
+
+        See {!page-"feature-daily-notes".recognition}. *)
+
+    let today = date 2026 7 26
+
+    let table ?(folder : string option) (f : string) : Table.t =
+      Table.create
+        ~window_years:1
+        { default_settings with format = fmt_exn f; folder }
+        ~today
+    ;;
+
+    let%expect_test "date_of_path" =
+      let t = table ~folder:"journal" "YYYY/MM/YYYY-MM-DD" in
+      List.iter
+        [ "journal/2026/07/2026-07-06.md"
+        ; "journal/2026/07/2026-07-06" (* no extension *)
+        ; "2026/07/2026-07-06.md" (* outside the folder *)
+        ; "journal/2026/07/not-a-date.md"
+        ; "journal/1999/01/1999-01-01.md" (* outside the window *)
+        ]
+        ~f:(fun p ->
+          match Table.date_of_path t p with
+          | Some d -> printf "%-32s -> %s\n" p (Date.to_string d)
+          | None -> printf "%-32s -> not a daily note\n" p);
+      [%expect
+        {|
+        journal/2026/07/2026-07-06.md    -> 2026-07-06
+        journal/2026/07/2026-07-06       -> not a daily note
+        2026/07/2026-07-06.md            -> not a daily note
+        journal/2026/07/not-a-date.md    -> not a daily note
+        journal/1999/01/1999-01-01.md    -> not a daily note
+        |}]
+    ;;
+
+    (* Round-trip: rendering a date and recognizing the result must return the
+       same date, for every date in the window and every supported format.
+       This is the obligation that lets recognition skip a strict parser. *)
+    let%test_unit "round-trip: path_of_date then date_of_path" =
+      List.iter
+        [ "YYYY-MM-DD"
+        ; "YYYY/MM/YYYY-MM-DD"
+        ; "MMMM D, YYYY"
+        ; "Do MMM YY"
+        ; "[d] YYYY-MM-DD"
+        ]
+        ~f:(fun f ->
+          let t = table f in
+          Array.iter t.Table.dates ~f:(fun d ->
+            let path = path_of_date t.Table.settings d in
+            [%test_result: Date.t option]
+              ~message:(sprintf "format %s, date %s" f (Date.to_string d))
+              (Table.date_of_path t path)
+              ~expect:(Some d)))
+    ;;
+
+    (* A format with no day token maps a whole month to one note; the earliest
+       date in the month wins, so recognition stays deterministic. *)
+    let%expect_test "format without a day token" =
+      let t = table "YYYY-MM" in
+      print_s [%sexp (Table.date_of_path t "2026-07.md" : Date.t option)];
+      [%expect {| (2026-07-01) |}]
+    ;;
+
+    (** {2 Previous / next existing}
+
+        Calendar-independent: these skip gaps and never create. *)
+
+    let%expect_test "previous and next skip gaps" =
+      let t = table "YYYY-MM-DD" in
+      let existing =
+        String.Set.of_list [ "2026-07-03.md"; "2026-07-10.md"; "2026-07-26.md" ]
+      in
+      let exists p = Set.mem existing p in
+      let show label = function
+        | Some (d, p) -> printf "%-24s -> %s (%s)\n" label (Date.to_string d) p
+        | None -> printf "%-24s -> none\n" label
+      in
+      show "prev of 07-10" (Table.previous_existing t ~exists (date 2026 7 10));
+      show "next of 07-10" (Table.next_existing t ~exists (date 2026 7 10));
+      show "prev of 07-03" (Table.previous_existing t ~exists (date 2026 7 3));
+      show "next of 07-26" (Table.next_existing t ~exists (date 2026 7 26));
+      show "prev of 07-05 (gap)" (Table.previous_existing t ~exists (date 2026 7 5));
+      [%expect
+        {|
+        prev of 07-10            -> 2026-07-03 (2026-07-03.md)
+        next of 07-10            -> 2026-07-26 (2026-07-26.md)
+        prev of 07-03            -> none
+        next of 07-26            -> none
+        prev of 07-05 (gap)      -> 2026-07-03 (2026-07-03.md)
+        |}]
+    ;;
+
+    let%expect_test "is_daily_note" =
+      let t = table ~folder:"journal" "YYYY-MM-DD" in
+      printf
+        "%b %b\n"
+        (Table.is_daily_note t "journal/2026-07-26.md")
+        (Table.is_daily_note t "notes/idea.md");
+      [%expect {| true false |}]
+    ;;
+  end)
+;;

--- a/pkg/oystermark/lsp/docs/design-260322-lsp.mld
+++ b/pkg/oystermark/lsp/docs/design-260322-lsp.mld
@@ -97,8 +97,9 @@ optimisation could cache the parsed AST per file and invalidate on
 The resolved target is mapped to a file path and line number.  For
 [Heading] and [Block] targets, the target file is parsed and the line
 number is read from the heading/block-ID AST node's [Textloc] metadata
-(using heading slugs from {!Oystermark.Parse.Heading_slug} and block IDs
-from {!Cmarkit.Block.Block_id}).
+(using heading identifiers from {!Oystermark.Parse.Common.heading_id}, matched
+against a fragment written as text with {!Oystermark.Parse.Common.heading_id_of_text},
+and block IDs from {!Cmarkit.Block.Block_id}).
 
 {1 Editor setup}
 

--- a/pkg/oystermark/lsp/docs/feature-command-block.mld
+++ b/pkg/oystermark/lsp/docs/feature-command-block.mld
@@ -1,0 +1,117 @@
+{0 Command block}
+
+A fenced code block that turns server commands into visible, clickable text in
+the note you are editing.
+
+{1 Why}
+
+Code actions are the protocol's standard surface for "do a thing here", and
+every feature that offers one keeps offering it. But as a surface they are
+{e transient}: they appear only while the cursor sits somewhere the server
+finds interesting, they are reached through a menu, and a client cannot
+generally bind a key to one particular action among the several offered — some
+have no convenient path to them at all, Zed among them.
+
+A code lens is the same command with the opposite properties: rendered in the
+buffer, always visible, clickable, and anchored to a line rather than to a
+cursor position. This feature {b lifts} commands from the one surface to the
+other. Nothing is taken away — the code actions remain exactly as they were —
+and the lens is an alternative route to the same {!Lsp_lib.Server.execute_command}.
+
+Anchoring to a line rather than a cursor buys the second half of the idea: a
+block of them reads as a small {b control panel}, kept wherever it is useful,
+listing the operations that matter for the note it sits in.
+
+{1:syntax Syntax}
+
+A fenced code block whose info string is [oysterlsp]. One command per line:
+
+{@markdown[
+```oysterlsp
+# jump around the journal
+daily/today
+daily/prev
+daily/next
+```
+]}
+
+Inside a fenced block the content is literal text, not markdown, so a line is
+exactly its command name. Blank lines are ignored, and so is any line whose
+first non-blank character is [#], which makes comments and headings possible in
+a panel of any size.
+
+A note may hold any number of these blocks, and the block may sit anywhere in
+the note.
+
+{1:commands Commands}
+
+{t
+  | Line | Does | Enabled when |
+  |------|------|--------------|
+  | [daily/today] | Opens today's daily note, creating it if missing | always |
+  | [daily/yesterday] | As above, for yesterday | always |
+  | [daily/tomorrow] | As above, for tomorrow | always |
+  | [daily/prev] | Opens the previous {e existing} daily note, relative to the host note | the host note is a daily note, and an earlier one exists |
+  | [daily/next] | As above, forwards | the host note is a daily note, and a later one exists |
+}
+
+See {!page-"feature-daily-notes"} for what these mean and how the dates are
+computed; the block adds no behavior of its own, only a way to reach them.
+
+[daily/prev] and [daily/next] are the reason the block lives in a note rather
+than in one file at the vault root: they are answered {e relative to the note
+containing them}. The same block means different things in two different daily
+notes, which is the point.
+
+{1:surfaces Surfaces}
+
+Each recognized line gets all of:
+
+{ul
+  {- a {b code lens}, carrying the same command a code action would.  Its title
+     is the action's — [Create yesterday's daily note] — so the line says what
+     it is and the lens says what will happen;}
+  {- a {b code action}, when the cursor is on that line, so the panel is usable
+     from the keyboard and in clients that do not render lenses.  On such a
+     line it is the {e only} action offered: the ordinary daily-note menu would
+     bury the one the line asked for under four others.  Everywhere else in the
+     note that menu is unchanged;}
+  {- {b completion} of the command names, inside the block only, so the
+     available set is discoverable without leaving the editor;}
+  {- a {b diagnostic} on a line that names no known command.  A misspelling
+     would otherwise be inert, and inert looks exactly like unimplemented.}
+}
+
+A command that is understood but not currently applicable — [daily/prev] in a
+note that is not a daily note, or one with nothing before it — keeps its lens,
+without a command attached, showing why: [no previous daily note]. A lens that
+vanishes would be indistinguishable from one the server failed to produce.
+
+{1:publishing Publishing}
+
+This is a {b dev-time} feature. The block is an ordinary code block to every
+other part of Oystermark: the parser reads it as one, the renderer prints it as
+one, and nothing here changes what a build produces. A block is expected to be
+deleted from a note before that note is published — no [Silent] handling, no
+pipeline hook, no interaction with {!Oystermark.Config}.
+
+{1:limitations Limitations}
+
+{ul
+  {- Commands take no arguments. Every line is a fixed name, so anything
+     needing a date, a path or a prompt has no expression here.}
+  {- The set of commands is closed and small: it is exactly the daily-note
+     family. Note-scoped operations that would justify the block further —
+     creating every unresolved link in a note, inserting a link to the note
+     into today's daily note — are not implemented.}
+  {- Lens rendering is a client capability. A client without it still gets the
+     code actions, which is the whole set of behavior minus the clicking.}
+  {- No lens is offered outside a command block, and no note is treated
+     specially by name.}
+}
+
+{1:test Test}
+
+Recognition and the command catalogue: {!Lsp_lib.Command_block}'s inline tests.
+The lenses, actions, completions and diagnostics a server answers with:
+[tests/lsp/test_command_block.ml].

--- a/pkg/oystermark/lsp/docs/feature-command-block.mld
+++ b/pkg/oystermark/lsp/docs/feature-command-block.mld
@@ -87,6 +87,26 @@ note that is not a daily note, or one with nothing before it — keeps its lens,
 without a command attached, showing why: [no previous daily note]. A lens that
 vanishes would be indistinguishable from one the server failed to produce.
 
+{1:insert Creating a block}
+
+The surfaces above all presuppose a block: completion offers the catalogue
+{e inside} one, so the names are discoverable only to someone who already knows
+the fence to type. A code action closes that circle — [Insert oysterlsp command
+block], offered anywhere in a note that has none, writing the fence and its
+lines at the cursor's line.
+
+It writes only the commands that {b can run in this note}, resolved exactly as
+the lenses resolve them — see the {e enabled when} column above: an ordinary
+note gets the calendar three, a daily note with neighbours on both sides gets
+all five. The alternative — always writing the catalogue — hands most notes two
+lines that the lenses immediately report as dead, and a panel is a list of the
+operations that matter here.
+
+The gate is the note, not the cursor: once a block exists the action stops
+being offered, since the way to add a line to a panel is to type it, with
+completion helping. A note where nothing resolves at all — daily notes are
+disabled — is offered nothing, there being no panel worth writing.
+
 {1:publishing Publishing}
 
 This is a {b dev-time} feature. The block is an ordinary code block to every
@@ -106,12 +126,15 @@ pipeline hook, no interaction with {!Oystermark.Config}.
      into today's daily note — are not implemented.}
   {- Lens rendering is a client capability. A client without it still gets the
      code actions, which is the whole set of behavior minus the clicking.}
+  {- An inserted block is written at column zero, so invoking the action from
+     inside a list item or a callout puts the fence outside it.}
   {- No lens is offered outside a command block, and no note is treated
      specially by name.}
 }
 
 {1:test Test}
 
-Recognition and the command catalogue: {!Lsp_lib.Command_block}'s inline tests.
-The lenses, actions, completions and diagnostics a server answers with:
-[tests/lsp/test_command_block.ml].
+Recognition, the command catalogue, and the text of a fresh block:
+{!Lsp_lib.Command_block}'s inline tests. The lenses, actions, completions and
+diagnostics a server answers with, and what the insert action writes into which
+note: [tests/lsp/test_command_block.ml].

--- a/pkg/oystermark/lsp/docs/feature-configuration.mld
+++ b/pkg/oystermark/lsp/docs/feature-configuration.mld
@@ -27,6 +27,7 @@ The same shape in both sources — one schema, one parser.
   | [dailyNotes.format] | string | [YYYY-MM-DD] | Date format naming the note. See {!page-"feature-daily-notes".format}. |
   | [dailyNotes.folder] | string | vault root | Vault-relative folder the daily notes live under. |
   | [dailyNotes.template] | string | none | {b Stubbed}. See {!page-"feature-daily-notes".limitations}. |
+  | [dailyNotes.linkAction] | bool | [true] | Whether to offer [Insert link to today's daily note]. See {!page-"feature-daily-notes".link}. |
   | [hover.maxChars] | positive int | [2000] | Bytes of note content a hover may include. See {!page-"feature-hover".truncation}. |
   | [goToDefinition.unresolvedFragment] | [fallback] \| [strict] | [fallback] | Where a link with an unfindable fragment goes. See {!page-"feature-go-to-definition"}. |
   | [diagnostics.unresolvedFragment] | [fallback] \| [strict] | [fallback] | Whether an unfindable fragment is reported. See {!page-"feature-diagnostics"}. |
@@ -41,6 +42,47 @@ A complete example:
     "goToDefinition": { "unresolvedFragment": "strict" }
   }
 ]}
+
+{1:schema-file Discovering the schema}
+
+The table above is the specification; [lsp/oysterlsp.schema.json] is the same
+thing in a form editors can act on. Naming it from the file itself is enough —
+a JSON language server picks it up with no editor configuration — and gives
+completion of every key, validation of every value, and the [description] text
+on hover:
+
+{[
+  {
+    "$schema": "https://raw.githubusercontent.com/hon-gyu/oyster/main/pkg/oystermark/lsp/oysterlsp.schema.json",
+    "dailyNotes": { "format": "YYYY-MM-DD" }
+  }
+]}
+
+The URL is the {b raw} one: a [github.com/…/blob/…] link serves an HTML page,
+which a JSON language server cannot read. It tracks [main], so a vault picks up
+new settings as they land; pin a tag in place of [main] to hold a version
+still.
+
+[$schema] is accepted and ignored by the parser: it is an editor association,
+not a setting, and reporting it as an unknown key would penalize the one line
+that makes the file self-describing.
+
+For a starting file, [oystermark-lsp --print-default-config] writes every key
+at its default, with the association line already in place. It is meant as a
+file to {e edit}, not one to keep whole: a written-down default is frozen at
+the value it had the day it was written, while an omitted key follows this
+server as it changes.
+
+{2 Against drift}
+
+A published schema is a second statement of what the parser accepts, and two
+statements drift — a schema key the parser rejects would advertise a setting
+that does nothing, and a parser key the schema omits would be flagged as
+invalid in the user's editor. Both directions are tested against
+{!Lsp_lib.Config.known_keys}, which is in turn checked against the parser
+itself: each inventoried key is fed a value of the wrong type, and the
+complaint must be about the {e value}, since an unknown key complains about
+the key. See [tests/lsp/test_config_schema.ml].
 
 {1:precedence Precedence}
 
@@ -99,12 +141,14 @@ server capabilities would remain restart-only.
   {- The file is looked for at the vault root only: no search upward from the
      edited file, no per-directory overrides.}
   {- JSON, so no comments. Consistent with {!Oystermark.Config}.}
-  {- No environment-variable or command-line source. The server takes no
-     arguments.}
+  {- No environment-variable or command-line source for {e settings}. The one
+     argument the binary takes, [--print-default-config], writes a file and
+     exits; it configures nothing.}
 }
 
 {1:test Test}
 
 Parsing, merging, and the warnings: {!Lsp_lib.Config}'s inline tests.
 End to end, from a file on disk through {!Lsp_lib.Server}:
-[tests/lsp/test_configuration.ml].
+[tests/lsp/test_configuration.ml].  The published schema against the parser,
+and the emitted default file against both: [tests/lsp/test_config_schema.ml].

--- a/pkg/oystermark/lsp/docs/feature-configuration.mld
+++ b/pkg/oystermark/lsp/docs/feature-configuration.mld
@@ -1,0 +1,110 @@
+{0 Configuration}
+
+Every knob the server exposes, where its value comes from, and what happens
+when that value is wrong.
+
+Two sources feed {!Lsp_lib.Config.t}: the client's [initializationOptions], and
+a file in the vault. The file exists because the settings below describe the
+{e vault} — how its daily notes are named, how strict its links are — not the
+editor looking at it. Those belong with the notes, shareable across the people
+and machines that share the vault, rather than duplicated in each contributor's
+editor settings.
+
+{1:file The file}
+
+[oysterlsp.json], at the vault root. Optional: its absence is not an error and
+not worth a message. This is {b not} {!Oystermark.Config}, which configures a
+vault {e build} and is passed by path on the command line; the two have no keys
+in common and are read by different programs.
+
+{1:schema Schema}
+
+The same shape in both sources — one schema, one parser.
+
+{t
+  | Key | Type | Default | Meaning |
+  |-----|------|---------|---------|
+  | [dailyNotes.format] | string | [YYYY-MM-DD] | Date format naming the note. See {!page-"feature-daily-notes".format}. |
+  | [dailyNotes.folder] | string | vault root | Vault-relative folder the daily notes live under. |
+  | [dailyNotes.template] | string | none | {b Stubbed}. See {!page-"feature-daily-notes".limitations}. |
+  | [hover.maxChars] | positive int | [2000] | Bytes of note content a hover may include. See {!page-"feature-hover".truncation}. |
+  | [goToDefinition.unresolvedFragment] | [fallback] \| [strict] | [fallback] | Where a link with an unfindable fragment goes. See {!page-"feature-go-to-definition"}. |
+  | [diagnostics.unresolvedFragment] | [fallback] \| [strict] | [fallback] | Whether an unfindable fragment is reported. See {!page-"feature-diagnostics"}. |
+}
+
+A complete example:
+
+{[
+  {
+    "dailyNotes": { "format": "YYYY/MM/YYYY-MM-DD", "folder": "journal" },
+    "hover": { "maxChars": 400 },
+    "goToDefinition": { "unresolvedFragment": "strict" }
+  }
+]}
+
+{1:precedence Precedence}
+
+The file wins, {b field by field}. A key set in [oysterlsp.json] overrides the
+same key from [initializationOptions]; a key the file omits keeps whatever the
+client sent, or the default. Objects are merged, not replaced: a file setting
+only [dailyNotes.folder] leaves a client-supplied [dailyNotes.format] standing.
+
+The file wins because it is the vault's own description of itself and travels
+with the notes, whereas [initializationOptions] is per-machine. A contributor
+whose editor sends a stale [dailyNotes.format] should still get the vault's
+naming, not their own.
+
+{1:tolerance Tolerance}
+
+Neither source can fail initialization. An unreadable file, malformed JSON, an
+unknown key, a value of the wrong type or outside its range: each falls back to
+what it would have been, and the server starts.
+
+Silence, though, is the failure mode worth avoiding — a setting that is ignored
+without comment is indistinguishable from a setting that does not exist. So
+every fallback is {b reported}: parsing yields warnings alongside the config,
+{!Lsp_lib.Server.config_warnings} holds them, and the adapter sends each as a
+[window/showMessage] of severity [Warning] at initialize. A correct
+configuration produces none.
+
+Each warning names its source and its key, so [oysterlsp.json] and the client
+are distinguishable:
+
+{[
+  oysterlsp.json: hover.maxChars: expected a positive integer, got "400px"
+  oysterlsp.json: unknown key "dailynotes"
+  initializationOptions: goToDefinition.unresolvedFragment: expected "fallback" or "strict", got "lenient"
+]}
+
+An unknown key is reported rather than ignored: a misspelled key is otherwise
+the quietest way to have a setting do nothing. A rejected
+[dailyNotes.format] is reported through the same channel, though it is
+validated later — see {!page-"feature-daily-notes".format}.
+
+{1:reload Reload}
+
+The file is read {b once}, at [initialize], like [initializationOptions]. A
+later edit takes effect when the server restarts.
+
+{b Not yet implemented}: watching the file. Live reload wants a
+[workspace/didChangeWatchedFiles] registration and invalidation of everything
+derived from the config — the memoized daily-note table in particular. Note
+that it could never be complete: what a server advertises in its [initialize]
+result cannot be withdrawn afterwards, so any future setting reflected in
+server capabilities would remain restart-only.
+
+{1:limitations Limitations}
+
+{ul
+  {- The file is looked for at the vault root only: no search upward from the
+     edited file, no per-directory overrides.}
+  {- JSON, so no comments. Consistent with {!Oystermark.Config}.}
+  {- No environment-variable or command-line source. The server takes no
+     arguments.}
+}
+
+{1:test Test}
+
+Parsing, merging, and the warnings: {!Lsp_lib.Config}'s inline tests.
+End to end, from a file on disk through {!Lsp_lib.Server}:
+[tests/lsp/test_configuration.ml].

--- a/pkg/oystermark/lsp/docs/feature-daily-notes.mld
+++ b/pkg/oystermark/lsp/docs/feature-daily-notes.mld
@@ -26,10 +26,11 @@ always Sunday.
 
 {1 Settings}
 
-Settings are Oystermark's own, delivered through the LSP
-[initializationOptions] under the [dailyNotes] key, and stored in
-{!Lsp_lib.Config}. Obsidian's [.obsidian/daily-notes.json] is {b not} read:
-a vault's Obsidian configuration is not ours to depend on.
+Settings are Oystermark's own, read under the [dailyNotes] key from
+[oysterlsp.json] or the LSP [initializationOptions] — see
+{!page-"feature-configuration"} for the sources and how they combine — and
+stored in {!Lsp_lib.Config}. Obsidian's [.obsidian/daily-notes.json] is
+{b not} read: a vault's Obsidian configuration is not ours to depend on.
 
 {t
   | Key        | Type   | Default | Meaning |
@@ -81,11 +82,16 @@ A rejection is {b reported}, once, as a [window/showMessage] of severity
 action is also what a correctly configured server does when it has nothing to
 offer, so without the message a mistyped format would be indistinguishable from
 a feature that is simply absent. {!Lsp_lib.Config.daily_notes_settings}
-computes the error, {!Lsp_lib.Server.daily_notes_error} holds it from
-initialize onward, and the adapter sends it.
+computes the error and {!Lsp_lib.Server.config_warnings} carries it from
+initialize onward, alongside every other configuration complaint; see
+{!page-"feature-configuration".tolerance}.
 
-Nothing is reported later: the settings arrive once, so a repeat on every code
-action would say the same thing indefinitely.
+The format is the one setting validated on {e use} rather than at parse time —
+whether it is usable is a property of its value, not its type — but it is
+reported through the same channel, at the same moment.
+
+Nothing is reported later: the settings are read once, so a repeat on every
+code action would say the same thing indefinitely.
 
 A format is also rejected when it starts with [/], or when the text it produces
 contains a path-illegal character. This matches the validation Obsidian's

--- a/pkg/oystermark/lsp/docs/feature-daily-notes.mld
+++ b/pkg/oystermark/lsp/docs/feature-daily-notes.mld
@@ -152,6 +152,40 @@ The calendar actions' titles state what will happen when the note is missing:
 [Create today's daily note] when it does not exist, [Open today's daily note]
 when it does.
 
+{2:link Linking instead of opening}
+
+One further action, [Insert link to today's daily note], writes [ [[2026-07-26]] ]
+at the cursor and creates the note if it is missing, in a single edit so the
+link resolves the moment it lands.
+
+It is the only member of the family that reaches its note {e without}
+[window/showDocument]: a [WorkspaceEdit] is all it asks for, and the link it
+leaves behind is followed by go-to-definition. Where focusing is unavailable
+(see {!focus}) this is the working route to today's note, at the cost of
+navigation that writes to the buffer — the link stays until it is deleted,
+which is why it is offered as a link rather than performed as a hidden step of
+the other actions.
+
+The link is the note's base name, not its path. Link resolution matches a path
+subsequence, so [ [[2026-07-26]] ] finds [2026/07/2026-07-26.md] under a nested
+format; a reader is spared the folders, and the link keeps working if the
+[folder] setting later changes.
+
+It is also the only action here offered in {e every} menu in the vault — the
+others are at least about navigating, while this one is an editing offer made
+wherever the cursor happens to be. In a vault where daily notes are not part of
+the writing habit that is noise, so it can be turned off on its own:
+
+{@json[
+{ "dailyNotes": { "linkAction": false } }
+]}
+
+Turning it off leaves the rest of the family intact; it is not a way to disable
+daily notes, which is what an unsupported [format] does. Where
+[window/showDocument] is missing, though, this action is the only route to the
+note, so switching it off there gives up reaching daily notes altogether — a
+trade worth making knowingly.
+
 {2 Mechanism}
 
 A code action cannot itself focus an editor, so each action carries a command,
@@ -166,9 +200,34 @@ and a flag saying whether it must be created. Executing it:
   {- requests [window/showDocument] with [takeFocus] to open it.}
 }
 
-The server therefore advertises [executeCommandProvider] for that command. When
-the client does not advertise [window.showDocument], the note is still created
-and the action reports the path rather than silently doing half the job.
+The server therefore advertises [executeCommandProvider] for that command.
+
+{2:focus Focusing is the client's}
+
+Step 2 is the one effect the server cannot perform itself, and it is optional
+in the protocol. A client may:
+
+{ul
+  {- not advertise [window.showDocument] — then the request is never sent;}
+  {- advertise it and answer [success: false] — then it was sent and declined.}
+}
+
+Both end the same way: the note exists and nothing opened. Either case reports
+the path through [window/showMessage], because a command that finishes in
+silence is indistinguishable from one that failed. The [executeCommand] result
+is the path as well, for a client scripting against the server.
+
+The consequence is worth stating plainly: where the capability is missing, a
+command that only opens — [daily/today] on a note that already exists — does
+nothing visible but the message, while a command that {e creates} still puts a
+file on disk, since [workspace/applyEdit] is the better-supported half. Editors
+differ here and some in current use are on the wrong side of it (Zed, for one,
+neither advertises nor implements the request). Nothing in this server can make
+a client focus a document; closing that gap is client-side work.
+
+What the server {e can} do is offer a route that needs no such capability:
+{!link} writes a wikilink to the note, and go-to-definition follows it. That is
+the supported answer for these clients, and the reason the action exists.
 
 {1 Testing}
 
@@ -196,5 +255,8 @@ Property-based testing fits the round-trip obligation and is preferred there.
   {- {b English month and weekday names only}.}
   {- {b No Obsidian config}: a vault configured only through Obsidian's settings
      needs its [format] restated in [initializationOptions].}
+  {- {b Opening depends on the client} (see {!focus}): where
+     [window/showDocument] is unsupported, the command reports the path instead
+     of focusing it.}
   {- Positions and edits follow {!page-"feature-utf16-positions"}.}
 }

--- a/pkg/oystermark/lsp/docs/feature-daily-notes.mld
+++ b/pkg/oystermark/lsp/docs/feature-daily-notes.mld
@@ -76,10 +76,16 @@ no daily-note action is offered — rather than silently naming the wrong file.
 Week-based tokens ([ww], [gggg]) are excluded on purpose: they do not identify a
 single day.
 
-{b Not yet implemented}: the rejection is silent. The validation error is
-computed ({!Lsp_lib.Config.daily_notes_settings} returns it) but never reaches
-the user, so a mistyped format looks like a missing feature. Surfacing it as a
-[window/showMessage] at initialize is the obvious fix.
+A rejection is {b reported}, once, as a [window/showMessage] of severity
+[Warning] at initialize, naming what was wrong with the format. Offering no
+action is also what a correctly configured server does when it has nothing to
+offer, so without the message a mistyped format would be indistinguishable from
+a feature that is simply absent. {!Lsp_lib.Config.daily_notes_settings}
+computes the error, {!Lsp_lib.Server.daily_notes_error} holds it from
+initialize onward, and the adapter sends it.
+
+Nothing is reported later: the settings arrive once, so a repeat on every code
+action would say the same thing indefinitely.
 
 A format is also rejected when it starts with [/], or when the text it produces
 contains a path-illegal character. This matches the validation Obsidian's

--- a/pkg/oystermark/lsp/docs/feature-daily-notes.mld
+++ b/pkg/oystermark/lsp/docs/feature-daily-notes.mld
@@ -1,0 +1,188 @@
+{0 Daily notes}
+
+Navigate to, and create on demand, the note for a calendar day. This mirrors
+Obsidian's {b Daily notes} core plugin — see
+[specification/obsidian/daily-notes.md] for the reference behavior it was
+decoded from — and adds the calendar-relative jumps that Obsidian's core does
+not provide.
+
+{1 Scope}
+
+Two families of navigation, deliberately kept distinct because their semantics
+differ:
+
+{ul
+  {- {b Calendar}: today, yesterday, tomorrow. Addressed by date arithmetic,
+     independent of what exists on disk, and {e creating} the note when it is
+     missing.}
+  {- {b Existing}: previous, next. Addressed by scanning the daily notes that
+     exist, relative to the date of the current file, and {e never} creating
+     anything. This is Obsidian's [daily-notes:goto-prev] / [goto-next].}
+}
+
+Conflating them would be a mistake: "previous" from a Monday note is the
+preceding {e daily note}, which may be days earlier, whereas "yesterday" is
+always Sunday.
+
+{1 Settings}
+
+Settings are Oystermark's own, delivered through the LSP
+[initializationOptions] under the [dailyNotes] key, and stored in
+{!Lsp_lib.Config}. Obsidian's [.obsidian/daily-notes.json] is {b not} read:
+a vault's Obsidian configuration is not ours to depend on.
+
+{t
+  | Key        | Type   | Default | Meaning |
+  |------------|--------|---------|---------|
+  | [format]   | string | [YYYY-MM-DD] | Date format naming the note. May contain [/], which nests it in folders. |
+  | [folder]   | string | vault root   | Vault-relative folder the daily notes live under. |
+  | [template] | string | none         | {b Stubbed}: parsed and carried, ignored by note creation. See {!limitations}. |
+}
+
+Wiring [initializationOptions] into {!Lsp_lib.Config} is part of this
+feature: the record exists today but the server never populates it.
+
+An unparseable [dailyNotes] object leaves the defaults in place rather than
+failing initialization, matching {!Oystermark.Config}'s tolerance for stale
+config.
+
+{2:format Date format}
+
+The format is a subset of the {{:https://momentjs.com/docs/#/displaying/format/}
+moment.js} tokens, chosen so that a format written for Obsidian keeps naming the
+same file here.
+
+{t
+  | Token | Meaning | Example (2026-07-06) |
+  |-------|---------|----------------------|
+  | [YYYY] | 4-digit year | [2026] |
+  | [YY] | 2-digit year | [26] |
+  | [MM] | zero-padded month | [07] |
+  | [M] | month | [7] |
+  | [MMM] | abbreviated month name | [Jul] |
+  | [MMMM] | month name | [July] |
+  | [DD] | zero-padded day | [06] |
+  | [D] | day | [6] |
+  | [Do] | ordinal day | [6th] |
+  | [ddd] | abbreviated weekday | [Mon] |
+  | [dddd] | weekday | [Monday] |
+  | [\[...\]] | literal text | [\[Daily\]] → [Daily] |
+}
+
+Names are English-only; moment's locale machinery is out of scope.
+
+Any other token is {b rejected}: an unsupported format disables the feature —
+no daily-note action is offered — rather than silently naming the wrong file.
+Week-based tokens ([ww], [gggg]) are excluded on purpose: they do not identify a
+single day.
+
+{b Not yet implemented}: the rejection is silent. The validation error is
+computed ({!Lsp_lib.Config.daily_notes_settings} returns it) but never reaches
+the user, so a mistyped format looks like a missing feature. Surfacing it as a
+[window/showMessage] at initialize is the obvious fix.
+
+A format is also rejected when it starts with [/], or when the text it produces
+contains a path-illegal character. This matches the validation Obsidian's
+settings tab applies.
+
+{1 Path computation}
+
+For a date [d]:
+
+{ol
+  {- [name] is [d] rendered through {!format}, then trimmed;}
+  {- the path is [folder ^ "/" ^ name ^ ".md"], or [name ^ ".md"] when [folder]
+     is unset;}
+  {- the path is looked up in the vault index. An existing note is used as-is.}
+}
+
+Because [format] may contain [/], the path may name folders that do not exist;
+creating a daily note creates them.
+
+Unlike Obsidian, lookup is {b case-sensitive} and an unset [folder] means the
+vault root exactly — Obsidian falls back to its app-level "default location for
+new notes", which is a setting we do not have.
+
+{1:recognition Recognition}
+
+Answering "is the current file a daily note, and for which date?" is the inverse
+of {!format}. Rather than write a strict parser, the inverse is obtained by
+{b candidate generation}: for every date in a window around today, render the
+format and record [path -> date] in a table.
+
+{ul
+  {- The window is today ± 5 years, rebuilt when the format changes.}
+  {- Correct by construction: recognition can never disagree with the formatter,
+     which is the bug a hand-written parser would invite.}
+  {- The cost is a bounded range: a note dated outside the window is not
+     recognized as a daily note. This is a deliberate trade, not an oversight.}
+}
+
+The {e existing} family uses this table intersected with the vault index: a file
+is a daily note iff its vault-relative path is a key of the table.
+
+{1 Actions}
+
+Offered as code actions on any Markdown file in the vault, under the
+[refactor] kind — they are not quick fixes, as no diagnostic underlies them.
+
+{t
+  | Title | Date | Creates? | Available when |
+  |-------|------|----------|----------------|
+  | [Open today's daily note] | today | yes | always |
+  | [Open yesterday's daily note] | the day before today | yes | always |
+  | [Open tomorrow's daily note] | the day after today | yes | always |
+  | [Open previous daily note] | latest daily note strictly before the current file's date | no | current file is a daily note and such a note exists |
+  | [Open next daily note] | earliest daily note strictly after it | no | current file is a daily note and such a note exists |
+}
+
+The calendar actions' titles state what will happen when the note is missing:
+[Create today's daily note] when it does not exist, [Open today's daily note]
+when it does.
+
+{2 Mechanism}
+
+A code action cannot itself focus an editor, so each action carries a command,
+[oystermark.dailyNote.open], whose argument is the resolved vault-relative path
+and a flag saying whether it must be created. Executing it:
+
+{ol
+  {- creates the note — parent folders included — through a
+     [workspace/applyEdit] carrying a [CreateFile] edit, when the flag is set
+     and nothing is there. An existing file is never overwritten
+     ([ignoreIfExists]);}
+  {- requests [window/showDocument] with [takeFocus] to open it.}
+}
+
+The server therefore advertises [executeCommandProvider] for that command. When
+the client does not advertise [window.showDocument], the note is still created
+and the action reports the path rather than silently doing half the job.
+
+{1 Testing}
+
+{ul
+  {- Formatting: a table-driven expect test over the supported tokens, including
+     a format with [/] and one with a [\[literal\]].}
+  {- Round-trip: for a set of formats, every date in a sample range renders to a
+     path that the recognition table maps back to the same date.}
+  {- Rejection: unsupported and path-illegal formats disable the feature.}
+  {- Actions: a fixture vault with notes on non-consecutive days, asserting that
+     previous/next skip gaps, that they are unavailable off a daily note and at
+     the ends of the range, and that the calendar actions resolve to the right
+     path whether or not it exists.}
+}
+
+Property-based testing fits the round-trip obligation and is preferred there.
+
+{1:limitations Limitations and assumptions}
+
+{ul
+  {- {b Template is stubbed}: the setting round-trips but creation always makes
+     an empty note. Obsidian additionally resolves [{{title}}] in the template
+     body; when this is implemented it should match.}
+  {- {b Bounded recognition window} (see {!recognition}).}
+  {- {b English month and weekday names only}.}
+  {- {b No Obsidian config}: a vault configured only through Obsidian's settings
+     needs its [format] restated in [initializationOptions].}
+  {- Positions and edits follow {!page-"feature-utf16-positions"}.}
+}

--- a/pkg/oystermark/lsp/docs/feature-index.mld
+++ b/pkg/oystermark/lsp/docs/feature-index.mld
@@ -19,6 +19,7 @@
   {- {!page-"feature-daily-notes"}}
   {- {!page-"feature-inlay-hints"}}
   {- {!page-"feature-completion"}}
+  {- {!page-"feature-configuration"}}
   {- {!page-"feature-utf16-positions"}}
   {- {!page-"feature-document-sync"}}
 }

--- a/pkg/oystermark/lsp/docs/feature-index.mld
+++ b/pkg/oystermark/lsp/docs/feature-index.mld
@@ -16,6 +16,7 @@
   {- {!page-"feature-rename"}}
   {- {!page-"feature-document-outline"}}
   {- {!page-"feature-codeaction-create-unresolved-link"}}
+  {- {!page-"feature-daily-notes"}}
   {- {!page-"feature-inlay-hints"}}
   {- {!page-"feature-completion"}}
   {- {!page-"feature-utf16-positions"}}

--- a/pkg/oystermark/lsp/docs/feature-index.mld
+++ b/pkg/oystermark/lsp/docs/feature-index.mld
@@ -19,6 +19,7 @@
   {- {!page-"feature-daily-notes"}}
   {- {!page-"feature-inlay-hints"}}
   {- {!page-"feature-completion"}}
+  {- {!page-"feature-command-block"}}
   {- {!page-"feature-configuration"}}
   {- {!page-"feature-utf16-positions"}}
   {- {!page-"feature-document-sync"}}

--- a/pkg/oystermark/lsp/dune
+++ b/pkg/oystermark/lsp/dune
@@ -5,6 +5,7 @@
   lsp_lib
   lsp_util
   lsp_config
+  daily_notes
   link_collect
   go_to_definition
   completion
@@ -16,7 +17,13 @@
   create_unresolved_note
   inlay_hints
   server)
- (libraries oystermark core linol.lsp trace.core)
+ (libraries
+  oystermark
+  core
+  core_unix.time_float_unix
+  yojson
+  linol.lsp
+  trace.core)
  (inline_tests)
  (preprocess
   (pps ppx_jane ppx_string)))

--- a/pkg/oystermark/lsp/dune
+++ b/pkg/oystermark/lsp/dune
@@ -6,6 +6,7 @@
   lsp_util
   lsp_config
   daily_notes
+  command_block
   link_collect
   go_to_definition
   completion

--- a/pkg/oystermark/lsp/find_references.ml
+++ b/pkg/oystermark/lsp/find_references.ml
@@ -98,7 +98,7 @@ let detect_target
        (match link_ref.fragment with
         | Some (Oystermark.Vault.Link_ref.Heading hs) ->
           let slug =
-            String.concat ~sep:"-" (List.map hs ~f:Oystermark.Parse.Heading_slug.slugify)
+            String.concat ~sep:"-" (List.map hs ~f:Oystermark.Parse.Common.heading_id_of_text)
           in
           Some (Path_heading { path; slug })
         | Some (Block_ref bid) -> Some (Path_block { path; block_id = bid })
@@ -110,7 +110,7 @@ let detect_target
        (match link_ref.fragment with
         | Some (Oystermark.Vault.Link_ref.Heading hs) ->
           let slug =
-            String.concat ~sep:"-" (List.map hs ~f:Oystermark.Parse.Heading_slug.slugify)
+            String.concat ~sep:"-" (List.map hs ~f:Oystermark.Parse.Common.heading_id_of_text)
           in
           Some (Path_heading { path = rel_path; slug })
         | Some (Block_ref bid) -> Some (Path_block { path = rel_path; block_id = bid })
@@ -131,7 +131,7 @@ let detect_target
             String.lstrip line_str ~drop:(fun c -> Char.equal c '#')
             |> String.lstrip ~drop:(fun c -> Char.equal c ' ')
           in
-          let slug = Oystermark.Parse.Heading_slug.slugify text in
+          let slug = Oystermark.Parse.Common.heading_id_of_text text in
           Some (Path_heading { path = rel_path; slug })
         | None ->
           (match block_id_of_line line_str with

--- a/pkg/oystermark/lsp/go_to_definition.ml
+++ b/pkg/oystermark/lsp/go_to_definition.ml
@@ -285,15 +285,19 @@ let%test_module "go_to_definition" =
     let show_link ~(rel_path : string) ~(content : string) ~(label : string) needle =
       let offset = Option.value_exn (String.substr_index content ~pattern:needle) + 3 in
       let line, character = Lsp_util.position_of_byte_offset content offset in
-      let res = go_to_definition ~read_file ~index ~rel_path ~content ~line ~character () in
+      let res =
+        go_to_definition ~read_file ~index ~rel_path ~content ~line ~character ()
+      in
       match res with
       | None -> printf "%-28s -> unresolved\n" label
       | Some { path; line; character } ->
         printf "%-28s -> %s:%d:%d\n" label path line character
     ;;
 
-    let%expect_test "intra-note: {wikilink, markdown link} x {heading, block \
-                     attribute, inline attribute}" =
+    let%expect_test
+        "intra-note: {wikilink, markdown link} x {heading, block attribute, inline \
+         attribute}"
+      =
       let rel_path = "note-m.md" in
       let content = List.Assoc.find_exn files ~equal:String.equal rel_path in
       let show ~label needle = show_link ~rel_path ~content ~label needle in
@@ -303,7 +307,8 @@ let%test_module "go_to_definition" =
       show ~label:"markdown link x heading" "[h](#Mu)";
       show ~label:"markdown link x block attr" "[a](#aside)";
       show ~label:"markdown link x inline attr" "[k](#kt)";
-      [%expect {|
+      [%expect
+        {|
         wikilink x heading           -> note-m.md:1:0
         wikilink x block attr        -> note-m.md:6:0
         wikilink x inline attr       -> note-m.md:3:4

--- a/pkg/oystermark/lsp/go_to_definition.ml
+++ b/pkg/oystermark/lsp/go_to_definition.ml
@@ -150,6 +150,16 @@ let%test_module "go_to_definition" =
       ; "note-j.md", "# Kappa\n\nSee [[note-i#jp]].\n"
       ; "note-k.md", "---\ntitle: K\n---\n# Kap\n\nThe [x]{#fm} here.\n"
       ; "note-l.md", "# Lambda\n\nSee [[note-k#fm]].\n"
+        (* One note carrying all three anchor kinds, referenced by both link
+           syntaxes. See the intra-note matrix test below. *)
+      ; ( "note-m.md"
+        , "{#custom-h}\n\
+           # Mu\n\n\
+           The [key term]{#kt} is defined here.\n\n\
+           {#aside}\n\
+           > An aside.\n\n\
+           Wikilinks [[#Mu]] and [[#kt]] and [[#aside]].\n\n\
+           Markdown links [h](#Mu) and [k](#kt) and [a](#aside).\n" )
       ]
     ;;
 
@@ -249,6 +259,58 @@ let%test_module "go_to_definition" =
       let content = List.Assoc.find_exn files ~equal:String.equal "note-e.md" in
       show ~rel_path:"note-e.md" ~content ~line:2 ~character:12;
       [%expect {| (((path note-e.md) (line 0) (character 0))) |}]
+    ;;
+
+    (** {3 Intra-note anchor matrix}
+
+        Both link syntaxes reach all three anchor kinds through the one
+        fragment namespace: nothing in resolution is specific to wikilinks, and
+        nothing is specific to headings. See
+        {!page-"feature-attribute-anchors".resolution} for the namespace and
+        {!page-"feature-go-to-definition".resolution} for the jump.
+
+        note-m.md, whose lines are:
+        {[
+          0  {#custom-h}
+          1  # Mu
+          2
+          3  The [key term]{#kt} is defined here.
+          4
+          5  {#aside}
+          6  > An aside.
+        ]} *)
+
+    (* Place the cursor inside the link spelled [needle] and report where
+       go-to-definition lands. *)
+    let show_link ~(rel_path : string) ~(content : string) ~(label : string) needle =
+      let offset = Option.value_exn (String.substr_index content ~pattern:needle) + 3 in
+      let line, character = Lsp_util.position_of_byte_offset content offset in
+      let res = go_to_definition ~read_file ~index ~rel_path ~content ~line ~character () in
+      match res with
+      | None -> printf "%-28s -> unresolved\n" label
+      | Some { path; line; character } ->
+        printf "%-28s -> %s:%d:%d\n" label path line character
+    ;;
+
+    let%expect_test "intra-note: {wikilink, markdown link} x {heading, block \
+                     attribute, inline attribute}" =
+      let rel_path = "note-m.md" in
+      let content = List.Assoc.find_exn files ~equal:String.equal rel_path in
+      let show ~label needle = show_link ~rel_path ~content ~label needle in
+      show ~label:"wikilink x heading" "[[#Mu]]";
+      show ~label:"wikilink x block attr" "[[#aside]]";
+      show ~label:"wikilink x inline attr" "[[#kt]]";
+      show ~label:"markdown link x heading" "[h](#Mu)";
+      show ~label:"markdown link x block attr" "[a](#aside)";
+      show ~label:"markdown link x inline attr" "[k](#kt)";
+      [%expect {|
+        wikilink x heading           -> note-m.md:1:0
+        wikilink x block attr        -> note-m.md:6:0
+        wikilink x inline attr       -> note-m.md:3:4
+        markdown link x heading      -> note-m.md:1:0
+        markdown link x block attr   -> note-m.md:6:0
+        markdown link x inline attr  -> note-m.md:3:4
+        |}]
     ;;
   end)
 ;;

--- a/pkg/oystermark/lsp/hover.ml
+++ b/pkg/oystermark/lsp/hover.ml
@@ -142,7 +142,7 @@ let find_heading_in_content ~(slug : string) (content : string) : (int * int) op
         String.lstrip line ~drop:(fun c -> Char.equal c '#')
         |> String.lstrip ~drop:(fun c -> Char.equal c ' ')
       in
-      String.equal (Oystermark.Parse.Heading_slug.slugify text) slug)
+      String.equal (Oystermark.Parse.Common.heading_id_of_text text) slug)
   |> Option.map ~f:(fun (i, line) ->
     let level = heading_level_of_line line |> Option.value_exn in
     i, level)
@@ -208,7 +208,7 @@ let hover
                let slug =
                  String.concat
                    ~sep:"-"
-                   (List.map hs ~f:Oystermark.Parse.Heading_slug.slugify)
+                   (List.map hs ~f:Oystermark.Parse.Common.heading_id_of_text)
                in
                (match find_heading_in_content ~slug file_content with
                 | Some (hline, hlevel) ->
@@ -257,7 +257,7 @@ let hover
             let slug =
               String.concat
                 ~sep:"-"
-                (List.map hs ~f:Oystermark.Parse.Heading_slug.slugify)
+                (List.map hs ~f:Oystermark.Parse.Common.heading_id_of_text)
             in
             (match find_heading_in_content ~slug content with
              | Some (hline, hlevel) ->

--- a/pkg/oystermark/lsp/inlay_hints.ml
+++ b/pkg/oystermark/lsp/inlay_hints.ml
@@ -41,7 +41,7 @@ let headings_in_range
           String.lstrip line_str ~drop:(fun c -> Char.equal c '#')
           |> String.lstrip ~drop:(fun c -> Char.equal c ' ')
         in
-        let slug = Oystermark.Parse.Heading_slug.slugify text in
+        let slug = Oystermark.Parse.Common.heading_id_of_text text in
         let end_char = String.length line_str in
         Some (i, end_char, slug)))
 ;;

--- a/pkg/oystermark/lsp/justfile
+++ b/pkg/oystermark/lsp/justfile
@@ -1,0 +1,13 @@
+root := justfile_directory() / "../../.."
+
+default:
+    @just --list --justfile {{ justfile() }}
+
+# Rebuild the binary.
+build:
+    cd {{ root }} && dune build pkg/oystermark/lsp/main.exe
+
+install: build
+    cd {{ root }} && dune install oystermark --sections=bin
+    @echo "installed: $(command -v oystermark-lsp)"
+    @ls -l "$(command -v oystermark-lsp)"

--- a/pkg/oystermark/lsp/lsp_config.ml
+++ b/pkg/oystermark/lsp/lsp_config.ml
@@ -1,4 +1,8 @@
-(** LSP feature configuration. *)
+(** LSP feature configuration.
+
+    Spec: {!page-"feature-configuration"}. Values come from the client's
+    [initializationOptions] and from [oysterlsp.json] at the vault root; this
+    module parses both, merges them, and reports everything it had to ignore. *)
 
 open Core
 
@@ -56,42 +60,273 @@ let default =
   }
 ;;
 
-(** {1 Client-supplied configuration}
+(** {1:partial Parsing}
 
-    Settings arrive once, in [initialize]'s [initializationOptions].  Parsing is
-    tolerant by design: a malformed object leaves the defaults in place rather
-    than failing initialization, matching {!Oystermark.Config}. *)
+    A source is parsed into a {!Partial.t} — every field an option, recording
+    what that source {e said} rather than what the server should do — so that
+    two sources can be merged field by field before defaults are applied.  See
+    {!page-"feature-configuration".precedence}.
 
-let string_field (j : Yojson.Safe.t) (key : string) : string option =
+    Nothing here fails: an unusable value is dropped and described in a
+    warning.  See {!page-"feature-configuration".tolerance}. *)
+
+(** {!t} under a name {!Partial} can still refer to, having shadowed [t]. *)
+type resolved = t
+
+module Partial = struct
+  type nonrec daily_notes =
+    { format : string option
+    ; folder : string option
+    ; template : string option
+    }
+
+  type t =
+    { gtd_unresolved_fragment : fragment_behavior option
+    ; diag_unresolved_fragment : fragment_behavior option
+    ; hover_max_chars : int option
+    ; daily_notes : daily_notes
+    }
+
+  let empty =
+    { gtd_unresolved_fragment = None
+    ; diag_unresolved_fragment = None
+    ; hover_max_chars = None
+    ; daily_notes = { format = None; folder = None; template = None }
+    }
+  ;;
+
+  (** [merge ~lower ~upper] prefers [upper] wherever it has an opinion.  Nested
+      objects merge field-wise too, so a file naming only [dailyNotes.folder]
+      leaves a client-supplied [format] standing. *)
+  let merge ~(lower : t) ~(upper : t) : t =
+    let pick u l = Option.first_some u l in
+    { gtd_unresolved_fragment =
+        pick upper.gtd_unresolved_fragment lower.gtd_unresolved_fragment
+    ; diag_unresolved_fragment =
+        pick upper.diag_unresolved_fragment lower.diag_unresolved_fragment
+    ; hover_max_chars = pick upper.hover_max_chars lower.hover_max_chars
+    ; daily_notes =
+        { format = pick upper.daily_notes.format lower.daily_notes.format
+        ; folder = pick upper.daily_notes.folder lower.daily_notes.folder
+        ; template = pick upper.daily_notes.template lower.daily_notes.template
+        }
+    }
+  ;;
+end
+
+(** Fill a {!Partial.t}'s gaps from {!default}.  Outside {!Partial} so that the
+    record fields it builds are unambiguously {!t}'s. *)
+let resolve (p : Partial.t) : resolved =
+  { gtd_unresolved_fragment =
+      Option.value p.gtd_unresolved_fragment ~default:default.gtd_unresolved_fragment
+  ; diag_unresolved_fragment =
+      Option.value p.diag_unresolved_fragment ~default:default.diag_unresolved_fragment
+  ; hover_max_chars = Option.value p.hover_max_chars ~default:default.hover_max_chars
+  ; daily_notes =
+      { format = Option.value p.daily_notes.format ~default:default_daily_notes.format
+      ; folder = p.daily_notes.folder
+      ; template = p.daily_notes.template
+      }
+  }
+;;
+
+(** Accumulates what a source asked for and could not have.  See
+    {!page-"feature-configuration".tolerance}. *)
+module Warnings = struct
+  type t = { mutable rev : string list }
+
+  let create () = { rev = [] }
+  let add (t : t) (msg : string) : unit = t.rev <- msg :: t.rev
+  let to_list (t : t) : string list = List.rev t.rev
+
+  (** [~key] is the dotted path the user wrote, so a warning can be traced back
+      to a line in their config. *)
+  let bad_value (t : t) ~(key : string) ~(expected : string) (got : Yojson.Safe.t) : unit =
+    add t (sprintf "%s: expected %s, got %s" key expected (Yojson.Safe.to_string got))
+  ;;
+end
+
+let fields_exn (j : Yojson.Safe.t) : (string * Yojson.Safe.t) list option =
   match j with
-  | `Assoc fields ->
-    (match List.Assoc.find fields key ~equal:String.equal with
-     | Some (`String s) when not (String.is_empty (String.strip s)) ->
-       Some (String.strip s)
-     | _ -> None)
+  | `Assoc fields -> Some fields
   | _ -> None
 ;;
 
-(** [of_initialization_options j] reads [{ "dailyNotes": { ... } }].  Absent or
-    unusable fields keep their {!default}. *)
-let of_initialization_options (j : Yojson.Safe.t option) : t =
+(** A non-empty string, trimmed.  [""] and whitespace are treated as unusable
+    rather than as a deliberate empty value: no setting here has a meaningful
+    empty case. *)
+let parse_string (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t) : string option =
   match j with
-  | None -> default
+  | `String s when not (String.is_empty (String.strip s)) -> Some (String.strip s)
+  | got ->
+    Warnings.bad_value w ~key ~expected:"a non-empty string" got;
+    None
+;;
+
+let parse_positive_int (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t) : int option =
+  match j with
+  | `Int n when n > 0 -> Some n
+  | got ->
+    Warnings.bad_value w ~key ~expected:"a positive integer" got;
+    None
+;;
+
+let parse_fragment_behavior (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t)
+  : fragment_behavior option
+  =
+  match j with
+  | `String "fallback" -> Some Fallback
+  | `String "strict" -> Some Strict
+  | got ->
+    Warnings.bad_value w ~key ~expected:{|"fallback" or "strict"|} got;
+    None
+;;
+
+(** Walk an object's fields, dispatching known keys to [f] and reporting the
+    rest.  Reporting unknown keys is the point: a misspelled key is otherwise
+    the quietest possible way to have a setting do nothing. *)
+let parse_object
+      (w : Warnings.t)
+      ~(self : string)
+      ~(prefix : string)
+      (j : Yojson.Safe.t)
+      ~(f : key:string -> string -> Yojson.Safe.t -> bool)
+  : unit
+  =
+  match fields_exn j with
+  | None -> Warnings.bad_value w ~key:self ~expected:"an object" j
+  | Some fields ->
+    List.iter fields ~f:(fun (name, value) ->
+      let key = prefix ^ name in
+      if not (f ~key name value) then Warnings.add w (sprintf "unknown key %S" key))
+;;
+
+let parse_daily_notes (w : Warnings.t) (j : Yojson.Safe.t) : Partial.daily_notes =
+  let acc = ref { Partial.format = None; folder = None; template = None } in
+  parse_object w ~self:"dailyNotes" ~prefix:"dailyNotes." j ~f:(fun ~key name value ->
+    let str () = parse_string w ~key value in
+    match name with
+    | "format" ->
+      acc := { !acc with Partial.format = str () };
+      true
+    | "folder" ->
+      acc := { !acc with Partial.folder = str () };
+      true
+    | "template" ->
+      acc := { !acc with Partial.template = str () };
+      true
+    | _ -> false);
+  !acc
+;;
+
+(** [parse j] reads one source.  The shape is the same for both; only the
+    warning prefix differs, which the caller adds. *)
+let parse (j : Yojson.Safe.t) : Partial.t * string list =
+  let w = Warnings.create () in
+  let acc = ref Partial.empty in
+  parse_object w ~self:"configuration" ~prefix:"" j ~f:(fun ~key:_ name value ->
+    match name with
+    | "dailyNotes" ->
+      acc := { !acc with Partial.daily_notes = parse_daily_notes w value };
+      true
+    | "hover" ->
+      parse_object w ~self:"hover" ~prefix:"hover." value ~f:(fun ~key name value ->
+        match name with
+        | "maxChars" ->
+          acc := { !acc with Partial.hover_max_chars = parse_positive_int w ~key value };
+          true
+        | _ -> false);
+      true
+    | "goToDefinition" ->
+      parse_object
+        w
+        ~self:"goToDefinition"
+        ~prefix:"goToDefinition."
+        value
+        ~f:(fun ~key name value ->
+          match name with
+          | "unresolvedFragment" ->
+            acc
+            := { !acc with
+                 Partial.gtd_unresolved_fragment = parse_fragment_behavior w ~key value
+               };
+            true
+          | _ -> false);
+      true
+    | "diagnostics" ->
+      parse_object
+        w
+        ~self:"diagnostics"
+        ~prefix:"diagnostics."
+        value
+        ~f:(fun ~key name value ->
+          match name with
+          | "unresolvedFragment" ->
+            acc
+            := { !acc with
+                 Partial.diag_unresolved_fragment = parse_fragment_behavior w ~key value
+               };
+            true
+          | _ -> false);
+      true
+    | _ -> false);
+  !acc, Warnings.to_list w
+;;
+
+(** {1:sources Sources}
+
+    See {!page-"feature-configuration"}. *)
+
+(** The vault-root file. *)
+let file_name = "oysterlsp.json"
+
+(** Prefix each warning with where it came from, so [oysterlsp.json] and the
+    client are distinguishable in the message the user sees. *)
+let from (source : string) (warnings : string list) : string list =
+  List.map warnings ~f:(sprintf "%s: %s" source)
+;;
+
+let of_initialization_options (j : Yojson.Safe.t option) : Partial.t * string list =
+  match j with
+  | None -> Partial.empty, []
   | Some j ->
-    let daily =
-      match j with
-      | `Assoc fields ->
-        (match List.Assoc.find fields "dailyNotes" ~equal:String.equal with
-         | Some (`Assoc _ as d) ->
-           { format =
-               Option.value (string_field d "format") ~default:default_daily_notes.format
-           ; folder = string_field d "folder"
-           ; template = string_field d "template"
-           }
-         | _ -> default_daily_notes)
-      | _ -> default_daily_notes
-    in
-    { default with daily_notes = daily }
+    let partial, warnings = parse j in
+    partial, from "initializationOptions" warnings
+;;
+
+(** Read [oysterlsp.json] from [root].  An absent file is not a warning — the
+    file is optional; an unreadable or malformed one is. *)
+let of_vault_file ~(root : string) : Partial.t * string list =
+  let path = Filename.concat root file_name in
+  match Stdlib.Sys.file_exists path with
+  | false -> Partial.empty, []
+  | true ->
+    (match In_channel.read_all path |> Yojson.Safe.from_string with
+     | j ->
+       let partial, warnings = parse j in
+       partial, from file_name warnings
+     (* The whole file is lost — there is no partial parse to salvage — so the
+        message has to carry the parser's own position, folded onto one line
+        for a [showMessage]. *)
+     | exception Yojson.Json_error msg ->
+       ( Partial.empty
+       , [ sprintf
+             "%s: not valid JSON — %s"
+             file_name
+             (String.concat ~sep:" " (String.split_lines msg))
+         ] )
+     | exception exn ->
+       Partial.empty, [ sprintf "%s: unreadable — %s" file_name (Exn.to_string exn) ])
+;;
+
+(** [load ~root ~init_options] is the whole configuration story: both sources,
+    merged with the file on top, plus everything either source asked for and
+    could not have.  See {!page-"feature-configuration".precedence}. *)
+let load ~(root : string) ~(init_options : Yojson.Safe.t option) : t * string list =
+  let from_client, client_warnings = of_initialization_options init_options in
+  let from_file, file_warnings = of_vault_file ~root in
+  ( resolve (Partial.merge ~lower:from_client ~upper:from_file)
+  , client_warnings @ file_warnings )
 ;;
 
 (** [daily_notes_settings t] validates the configured format.  An [Error]
@@ -108,72 +343,209 @@ let daily_notes_settings (t : t) : (Daily_notes.settings, string) Result.t =
 
 (** {1:test Test} *)
 
-let%test_module "initialization options" =
+let%test_module "configuration" =
   (module struct
+    (** Parse one source and show the settings it resolves to on its own,
+        followed by every warning it produced. *)
     let show (s : string) =
-      let t = of_initialization_options (Some (Yojson.Safe.from_string s)) in
-      print_s [%sexp (t.daily_notes : daily_notes)];
-      match daily_notes_settings t with
-      | Ok settings ->
-        printf
-          "  -> %s\n"
-          (Daily_notes.path_of_date settings (Date.create_exn ~y:2026 ~m:Month.Jul ~d:6))
-      | Error e -> printf "  -> disabled: %s\n" e
+      let partial, warnings = parse (Yojson.Safe.from_string s) in
+      print_s [%sexp (resolve partial : t)];
+      List.iter warnings ~f:(printf "! %s\n")
     ;;
 
-    let%expect_test "well-formed" =
+    (** {2 Schema}
+
+        See {!page-"feature-configuration".schema}. *)
+
+    let%expect_test "every key" =
+      show
+        {|{ "dailyNotes": {"format": "YYYY/MM/YYYY-MM-DD", "folder": "journal",
+                           "template": "tpl.md"},
+            "hover": {"maxChars": 400},
+            "goToDefinition": {"unresolvedFragment": "strict"},
+            "diagnostics": {"unresolvedFragment": "strict"} }|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Strict) (diag_unresolved_fragment Strict)
+         (hover_max_chars 400)
+         (daily_notes
+          ((format YYYY/MM/YYYY-MM-DD) (folder (journal)) (template (tpl.md)))))
+        |}]
+    ;;
+
+    let%expect_test "empty object is the default" =
+      let partial, warnings = parse (`Assoc []) in
+      printf "%b %d\n" (equal (resolve partial) default) (List.length warnings);
+      [%expect {| true 0 |}]
+    ;;
+
+    (** {2 Tolerance}
+
+        Nothing here fails; everything ignored is named.  See
+        {!page-"feature-configuration".tolerance}. *)
+
+    let%expect_test "bad values fall back, with a warning each" =
+      show
+        {|{ "hover": {"maxChars": "400px"},
+            "goToDefinition": {"unresolvedFragment": "lenient"},
+            "dailyNotes": {"format": 42, "folder": "  "} }|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+        ! hover.maxChars: expected a positive integer, got "400px"
+        ! goToDefinition.unresolvedFragment: expected "fallback" or "strict", got "lenient"
+        ! dailyNotes.format: expected a non-empty string, got 42
+        ! dailyNotes.folder: expected a non-empty string, got "  "
+        |}]
+    ;;
+
+    (* Zero and negatives are rejected: a hover budget of nothing is far more
+       likely a mistake than an intent. *)
+    let%expect_test "maxChars must be positive" =
+      show {|{"hover": {"maxChars": 0}}|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+        ! hover.maxChars: expected a positive integer, got 0
+        |}]
+    ;;
+
+    (* A misspelled key is otherwise the quietest way to have a setting do
+       nothing, at either level of nesting. *)
+    let%expect_test "unknown keys are named" =
+      show {|{"dailynotes": {}, "hover": {"maxchars": 10}, "disable": ["hover"]}|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+        ! unknown key "dailynotes"
+        ! unknown key "hover.maxchars"
+        ! unknown key "disable"
+        |}]
+    ;;
+
+    let%expect_test "a source that is not an object" =
+      show {|"nonsense"|};
+      show {|{"dailyNotes": []}|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+        ! configuration: expected an object, got "nonsense"
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+        ! dailyNotes: expected an object, got []
+        |}]
+    ;;
+
+    (** {2 Precedence}
+
+        The file wins field by field.  See
+        {!page-"feature-configuration".precedence}. *)
+
+    let%expect_test "file overrides client, key by key" =
+      let client =
+        fst
+          (parse
+             (Yojson.Safe.from_string
+                {|
+        {"dailyNotes": {"format": "YYYY-MM-DD", "folder": "old"},
+         "hover": {"maxChars": 100}} |}))
+      in
+      let file =
+        fst (parse (Yojson.Safe.from_string {|{"dailyNotes": {"folder": "journal"}}|}))
+      in
+      print_s [%sexp (resolve (Partial.merge ~lower:client ~upper:file) : t)];
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 100)
+         (daily_notes ((format YYYY-MM-DD) (folder (journal)) (template ()))))
+        |}]
+    ;;
+
+    (** {2 The file}
+
+        See {!page-"feature-configuration".file}. *)
+
+    let with_root (contents : string option) ~f =
+      let root = Core_unix.mkdtemp "/tmp/oysterlsp-config" in
+      Option.iter contents ~f:(fun c ->
+        Out_channel.write_all (Filename.concat root file_name) ~data:c);
+      Exn.protect
+        ~f:(fun () -> f root)
+        ~finally:(fun () -> ignore (Stdlib.Sys.command (sprintf "rm -rf %s" root) : int))
+    ;;
+
+    let load_show ?init_options contents =
+      with_root contents ~f:(fun root ->
+        let init_options = Option.map init_options ~f:Yojson.Safe.from_string in
+        let t, warnings = load ~root ~init_options in
+        print_s [%sexp (t.daily_notes : daily_notes)];
+        List.iter warnings ~f:(printf "! %s\n"))
+    ;;
+
+    let%expect_test "no file: the client's settings stand" =
+      load_show None ~init_options:{|{"dailyNotes": {"folder": "from-client"}}|};
+      [%expect {| ((format YYYY-MM-DD) (folder (from-client)) (template ())) |}]
+    ;;
+
+    let%expect_test "file overrides the client, and says which source erred" =
+      load_show
+        (Some {|{"dailyNotes": {"folder": "from-file"}, "hover": {"maxChars": []}}|})
+        ~init_options:{|{"dailyNotes": {"folder": "from-client"}, "nope": 1}|};
+      [%expect
+        {|
+        ((format YYYY-MM-DD) (folder (from-file)) (template ()))
+        ! initializationOptions: unknown key "nope"
+        ! oysterlsp.json: hover.maxChars: expected a positive integer, got []
+        |}]
+    ;;
+
+    (* Malformed JSON loses the whole file — there is no partial parse to
+       salvage — but not the server. *)
+    let%expect_test "malformed file" =
+      load_show
+        (Some {|{"dailyNotes": {|})
+        ~init_options:{|{"dailyNotes": {"folder": "c"}}|};
+      [%expect
+        {|
+        ((format YYYY-MM-DD) (folder (c)) (template ()))
+        ! oysterlsp.json: not valid JSON — Line 1, bytes 15-16: Unexpected end of input
+        |}]
+    ;;
+
+    (** {2 Daily-note format}
+
+        Validated on demand rather than at parse time; see
+        {!page-"feature-daily-notes".format}. *)
+
+    let%expect_test "format is validated later" =
+      let show s =
+        let t = resolve (fst (parse (Yojson.Safe.from_string s))) in
+        match daily_notes_settings t with
+        | Ok settings ->
+          printf
+            "%s\n"
+            (Daily_notes.path_of_date
+               settings
+               (Date.create_exn ~y:2026 ~m:Month.Jul ~d:6))
+        | Error e -> printf "disabled: %s\n" e
+      in
       show {|{"dailyNotes": {"format": "YYYY/MM/YYYY-MM-DD", "folder": "journal"}}|};
-      [%expect
-        {|
-        ((format YYYY/MM/YYYY-MM-DD) (folder (journal)) (template ()))
-          -> journal/2026/07/2026-07-06.md
-        |}]
-    ;;
-
-    (* Tolerance: anything unusable falls back to the default rather than
-       failing initialization. *)
-    let%expect_test "malformed shapes fall back" =
-      List.iter
-        [ {|{}|}
-        ; {|{"dailyNotes": null}|}
-        ; {|{"dailyNotes": []}|}
-        ; {|{"dailyNotes": {"format": 42}}|}
-        ; {|{"dailyNotes": {"format": "  "}}|}
-        ; {|"not an object"|}
-        ]
-        ~f:show;
-      [%expect
-        {|
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        ((format YYYY-MM-DD) (folder ()) (template ()))
-          -> 2026-07-06.md
-        |}]
-    ;;
-
-    (* A syntactically fine but unsupported format parses into the config and
-       disables the feature at use time, with a message. *)
-    let%expect_test "unsupported format disables the feature" =
       show {|{"dailyNotes": {"format": "YYYY-ww"}}|};
       [%expect
         {|
-        ((format YYYY-ww) (folder ()) (template ()))
-          -> disabled: unsupported format token 'w'
+        journal/2026/07/2026-07-06.md
+        disabled: unsupported format token 'w'
         |}]
-    ;;
-
-    let%expect_test "none" =
-      let t = of_initialization_options None in
-      print_s [%sexp (equal t default : bool)];
-      [%expect {| true |}]
     ;;
   end)
 ;;

--- a/pkg/oystermark/lsp/lsp_config.ml
+++ b/pkg/oystermark/lsp/lsp_config.ml
@@ -13,6 +13,17 @@ type fragment_behavior =
       diagnostics report the fragment as unresolved. *)
 [@@deriving sexp, equal]
 
+(** Daily-note settings as written by the client, before validation.  Held as
+    strings so {!t} stays comparable; {!daily_notes_settings} turns them into a
+    {!Daily_notes.settings}, or an error when the format is unsupported.
+    See {!page-"feature-daily-notes"}. *)
+type daily_notes =
+  { format : string
+  ; folder : string option (** [None] is the vault root. *)
+  ; template : string option (** Carried; note creation ignores it (stubbed). *)
+  }
+[@@deriving sexp, equal]
+
 type t =
   { gtd_unresolved_fragment : fragment_behavior
     (** Fragment behavior for {!Go_to_definition}. *)
@@ -23,8 +34,16 @@ type t =
       response.  Content exceeding this limit is truncated at the
       previous newline and a [*(truncated)*] suffix is appended.
       See {!page-"feature-hover".truncation}. *)
+  ; daily_notes : daily_notes (** See {!page-"feature-daily-notes"}. *)
   }
 [@@deriving sexp, equal]
+
+let default_daily_notes =
+  { format = Daily_notes.Format.to_string Daily_notes.default_format
+  ; folder = None
+  ; template = None
+  }
+;;
 
 (** Default configuration: both features use {!Fallback}, matching the
     lenient behavior described in the go-to-definition spec.
@@ -33,5 +52,128 @@ let default =
   { gtd_unresolved_fragment = Fallback
   ; diag_unresolved_fragment = Fallback
   ; hover_max_chars = 2000
+  ; daily_notes = default_daily_notes
   }
+;;
+
+(** {1 Client-supplied configuration}
+
+    Settings arrive once, in [initialize]'s [initializationOptions].  Parsing is
+    tolerant by design: a malformed object leaves the defaults in place rather
+    than failing initialization, matching {!Oystermark.Config}. *)
+
+let string_field (j : Yojson.Safe.t) (key : string) : string option =
+  match j with
+  | `Assoc fields ->
+    (match List.Assoc.find fields key ~equal:String.equal with
+     | Some (`String s) when not (String.is_empty (String.strip s)) ->
+       Some (String.strip s)
+     | _ -> None)
+  | _ -> None
+;;
+
+(** [of_initialization_options j] reads [{ "dailyNotes": { ... } }].  Absent or
+    unusable fields keep their {!default}. *)
+let of_initialization_options (j : Yojson.Safe.t option) : t =
+  match j with
+  | None -> default
+  | Some j ->
+    let daily =
+      match j with
+      | `Assoc fields ->
+        (match List.Assoc.find fields "dailyNotes" ~equal:String.equal with
+         | Some (`Assoc _ as d) ->
+           { format =
+               Option.value (string_field d "format") ~default:default_daily_notes.format
+           ; folder = string_field d "folder"
+           ; template = string_field d "template"
+           }
+         | _ -> default_daily_notes)
+      | _ -> default_daily_notes
+    in
+    { default with daily_notes = daily }
+;;
+
+(** [daily_notes_settings t] validates the configured format.  An [Error]
+    disables the daily-note actions; the message names what was wrong.
+    See {!page-"feature-daily-notes".format}. *)
+let daily_notes_settings (t : t) : (Daily_notes.settings, string) Result.t =
+  Daily_notes.Format.of_string t.daily_notes.format
+  |> Result.map ~f:(fun format ->
+    { Daily_notes.format
+    ; folder = t.daily_notes.folder
+    ; template = t.daily_notes.template
+    })
+;;
+
+(** {1:test Test} *)
+
+let%test_module "initialization options" =
+  (module struct
+    let show (s : string) =
+      let t = of_initialization_options (Some (Yojson.Safe.from_string s)) in
+      print_s [%sexp (t.daily_notes : daily_notes)];
+      match daily_notes_settings t with
+      | Ok settings ->
+        printf
+          "  -> %s\n"
+          (Daily_notes.path_of_date settings (Date.create_exn ~y:2026 ~m:Month.Jul ~d:6))
+      | Error e -> printf "  -> disabled: %s\n" e
+    ;;
+
+    let%expect_test "well-formed" =
+      show {|{"dailyNotes": {"format": "YYYY/MM/YYYY-MM-DD", "folder": "journal"}}|};
+      [%expect
+        {|
+        ((format YYYY/MM/YYYY-MM-DD) (folder (journal)) (template ()))
+          -> journal/2026/07/2026-07-06.md
+        |}]
+    ;;
+
+    (* Tolerance: anything unusable falls back to the default rather than
+       failing initialization. *)
+    let%expect_test "malformed shapes fall back" =
+      List.iter
+        [ {|{}|}
+        ; {|{"dailyNotes": null}|}
+        ; {|{"dailyNotes": []}|}
+        ; {|{"dailyNotes": {"format": 42}}|}
+        ; {|{"dailyNotes": {"format": "  "}}|}
+        ; {|"not an object"|}
+        ]
+        ~f:show;
+      [%expect
+        {|
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        ((format YYYY-MM-DD) (folder ()) (template ()))
+          -> 2026-07-06.md
+        |}]
+    ;;
+
+    (* A syntactically fine but unsupported format parses into the config and
+       disables the feature at use time, with a message. *)
+    let%expect_test "unsupported format disables the feature" =
+      show {|{"dailyNotes": {"format": "YYYY-ww"}}|};
+      [%expect
+        {|
+        ((format YYYY-ww) (folder ()) (template ()))
+          -> disabled: unsupported format token 'w'
+        |}]
+    ;;
+
+    let%expect_test "none" =
+      let t = of_initialization_options None in
+      print_s [%sexp (equal t default : bool)];
+      [%expect {| true |}]
+    ;;
+  end)
 ;;

--- a/pkg/oystermark/lsp/lsp_config.ml
+++ b/pkg/oystermark/lsp/lsp_config.ml
@@ -25,6 +25,12 @@ type daily_notes =
   { format : string
   ; folder : string option (** [None] is the vault root. *)
   ; template : string option (** Carried; note creation ignores it (stubbed). *)
+  ; link_action : bool
+    (** Whether to offer [Insert link to today's daily note].  It is the one
+      daily-note action that reaches its note without
+      [window/showDocument], and the one that appears in every menu
+      whether or not the note is wanted there — so it is the one worth
+      turning off.  See {!page-"feature-daily-notes".link}. *)
   }
 [@@deriving sexp, equal]
 
@@ -46,6 +52,7 @@ let default_daily_notes =
   { format = Daily_notes.Format.to_string Daily_notes.default_format
   ; folder = None
   ; template = None
+  ; link_action = true
   }
 ;;
 
@@ -78,6 +85,7 @@ module Partial = struct
     { format : string option
     ; folder : string option
     ; template : string option
+    ; link_action : bool option
     }
 
   type t =
@@ -91,7 +99,7 @@ module Partial = struct
     { gtd_unresolved_fragment = None
     ; diag_unresolved_fragment = None
     ; hover_max_chars = None
-    ; daily_notes = { format = None; folder = None; template = None }
+    ; daily_notes = { format = None; folder = None; template = None; link_action = None }
     }
   ;;
 
@@ -109,6 +117,7 @@ module Partial = struct
         { format = pick upper.daily_notes.format lower.daily_notes.format
         ; folder = pick upper.daily_notes.folder lower.daily_notes.folder
         ; template = pick upper.daily_notes.template lower.daily_notes.template
+        ; link_action = pick upper.daily_notes.link_action lower.daily_notes.link_action
         }
     }
   ;;
@@ -126,6 +135,8 @@ let resolve (p : Partial.t) : resolved =
       { format = Option.value p.daily_notes.format ~default:default_daily_notes.format
       ; folder = p.daily_notes.folder
       ; template = p.daily_notes.template
+      ; link_action =
+          Option.value p.daily_notes.link_action ~default:default_daily_notes.link_action
       }
   }
 ;;
@@ -171,6 +182,14 @@ let parse_positive_int (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t) : in
     None
 ;;
 
+let parse_bool (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t) : bool option =
+  match j with
+  | `Bool b -> Some b
+  | got ->
+    Warnings.bad_value w ~key ~expected:"a boolean" got;
+    None
+;;
+
 let parse_fragment_behavior (w : Warnings.t) ~(key : string) (j : Yojson.Safe.t)
   : fragment_behavior option
   =
@@ -202,7 +221,9 @@ let parse_object
 ;;
 
 let parse_daily_notes (w : Warnings.t) (j : Yojson.Safe.t) : Partial.daily_notes =
-  let acc = ref { Partial.format = None; folder = None; template = None } in
+  let acc =
+    ref { Partial.format = None; folder = None; template = None; link_action = None }
+  in
   parse_object w ~self:"dailyNotes" ~prefix:"dailyNotes." j ~f:(fun ~key name value ->
     let str () = parse_string w ~key value in
     match name with
@@ -214,6 +235,9 @@ let parse_daily_notes (w : Warnings.t) (j : Yojson.Safe.t) : Partial.daily_notes
       true
     | "template" ->
       acc := { !acc with Partial.template = str () };
+      true
+    | "linkAction" ->
+      acc := { !acc with Partial.link_action = parse_bool w ~key value };
       true
     | _ -> false);
   !acc
@@ -269,8 +293,74 @@ let parse (j : Yojson.Safe.t) : Partial.t * string list =
             true
           | _ -> false);
       true
+    (* Not a setting: the association a JSON language server reads to offer
+       completion and validation over this very file.  Reporting it as unknown
+       would penalize the one line that makes the file self-documenting.  See
+       {!page-"feature-configuration".schema-file}. *)
+    | "$schema" -> true
     | _ -> false);
   !acc, Warnings.to_list w
+;;
+
+(** {1:keys Key inventory}
+
+    Every dotted key {!parse} accepts, [$schema] aside.  It exists to be
+    checked against — the published JSON Schema is a second statement of the
+    same thing, and two statements drift.  See
+    {!page-"feature-configuration".schema-file}. *)
+let known_keys : string list =
+  [ "dailyNotes.format"
+  ; "dailyNotes.folder"
+  ; "dailyNotes.template"
+  ; "dailyNotes.linkAction"
+  ; "hover.maxChars"
+  ; "goToDefinition.unresolvedFragment"
+  ; "diagnostics.unresolvedFragment"
+  ]
+;;
+
+(** Where the published schema lives: the [$schema] value
+    [--print-default-config] writes, and the [$id] the schema file itself
+    carries.  A raw URL, not a [github.com/blob] one — that serves HTML, which
+    a JSON language server cannot read.  See
+    {!page-"feature-configuration".schema-file}. *)
+let schema_url =
+  "https://raw.githubusercontent.com/hon-gyu/oyster/main/pkg/oystermark/lsp/oysterlsp.schema.json"
+;;
+
+(** {1:json Emitting}
+
+    The inverse of {!parse}, over a resolved {!t}: what a configuration file
+    would have to say to produce these settings.  Used by
+    [--print-default-config] to hand over a starting file. *)
+
+let json_of_fragment_behavior : fragment_behavior -> Yojson.Safe.t = function
+  | Fallback -> `String "fallback"
+  | Strict -> `String "strict"
+;;
+
+let to_json (t : t) : Yojson.Safe.t =
+  (* [folder] and [template] are optional with no default; omitting them says
+     "vault root" and "no template" more honestly than [null] would. *)
+  let optional key = function
+    | None -> []
+    | Some v -> [ key, `String v ]
+  in
+  `Assoc
+    [ ( "dailyNotes"
+      , `Assoc
+          ([ "format", `String t.daily_notes.format ]
+           @ optional "folder" t.daily_notes.folder
+           @ optional "template" t.daily_notes.template
+           @ [ "linkAction", `Bool t.daily_notes.link_action ]) )
+    ; "hover", `Assoc [ "maxChars", `Int t.hover_max_chars ]
+    ; ( "goToDefinition"
+      , `Assoc
+          [ "unresolvedFragment", json_of_fragment_behavior t.gtd_unresolved_fragment ] )
+    ; ( "diagnostics"
+      , `Assoc
+          [ "unresolvedFragment", json_of_fragment_behavior t.diag_unresolved_fragment ] )
+    ]
 ;;
 
 (** {1:sources Sources}
@@ -360,7 +450,7 @@ let%test_module "configuration" =
     let%expect_test "every key" =
       show
         {|{ "dailyNotes": {"format": "YYYY/MM/YYYY-MM-DD", "folder": "journal",
-                           "template": "tpl.md"},
+                           "template": "tpl.md", "linkAction": false},
             "hover": {"maxChars": 400},
             "goToDefinition": {"unresolvedFragment": "strict"},
             "diagnostics": {"unresolvedFragment": "strict"} }|};
@@ -369,7 +459,22 @@ let%test_module "configuration" =
         ((gtd_unresolved_fragment Strict) (diag_unresolved_fragment Strict)
          (hover_max_chars 400)
          (daily_notes
-          ((format YYYY/MM/YYYY-MM-DD) (folder (journal)) (template (tpl.md)))))
+          ((format YYYY/MM/YYYY-MM-DD) (folder (journal)) (template (tpl.md))
+           (link_action false))))
+        |}]
+    ;;
+
+    (* The switch is a plain boolean: anything else is dropped and named,
+       rather than being read as truthy. *)
+    let%expect_test "linkAction must be a boolean" =
+      show {|{"dailyNotes": {"linkAction": "no"}}|};
+      [%expect
+        {|
+        ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
+         (hover_max_chars 2000)
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
+        ! dailyNotes.linkAction: expected a boolean, got "no"
         |}]
     ;;
 
@@ -393,7 +498,8 @@ let%test_module "configuration" =
         {|
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 2000)
-         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
         ! hover.maxChars: expected a positive integer, got "400px"
         ! goToDefinition.unresolvedFragment: expected "fallback" or "strict", got "lenient"
         ! dailyNotes.format: expected a non-empty string, got 42
@@ -409,7 +515,8 @@ let%test_module "configuration" =
         {|
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 2000)
-         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
         ! hover.maxChars: expected a positive integer, got 0
         |}]
     ;;
@@ -422,7 +529,8 @@ let%test_module "configuration" =
         {|
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 2000)
-         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
         ! unknown key "dailynotes"
         ! unknown key "hover.maxchars"
         ! unknown key "disable"
@@ -436,11 +544,13 @@ let%test_module "configuration" =
         {|
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 2000)
-         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
         ! configuration: expected an object, got "nonsense"
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 2000)
-         (daily_notes ((format YYYY-MM-DD) (folder ()) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder ()) (template ()) (link_action true))))
         ! dailyNotes: expected an object, got []
         |}]
     ;;
@@ -467,7 +577,8 @@ let%test_module "configuration" =
         {|
         ((gtd_unresolved_fragment Fallback) (diag_unresolved_fragment Fallback)
          (hover_max_chars 100)
-         (daily_notes ((format YYYY-MM-DD) (folder (journal)) (template ()))))
+         (daily_notes
+          ((format YYYY-MM-DD) (folder (journal)) (template ()) (link_action true))))
         |}]
     ;;
 
@@ -494,7 +605,8 @@ let%test_module "configuration" =
 
     let%expect_test "no file: the client's settings stand" =
       load_show None ~init_options:{|{"dailyNotes": {"folder": "from-client"}}|};
-      [%expect {| ((format YYYY-MM-DD) (folder (from-client)) (template ())) |}]
+      [%expect
+        {| ((format YYYY-MM-DD) (folder (from-client)) (template ()) (link_action true)) |}]
     ;;
 
     let%expect_test "file overrides the client, and says which source erred" =
@@ -503,7 +615,7 @@ let%test_module "configuration" =
         ~init_options:{|{"dailyNotes": {"folder": "from-client"}, "nope": 1}|};
       [%expect
         {|
-        ((format YYYY-MM-DD) (folder (from-file)) (template ()))
+        ((format YYYY-MM-DD) (folder (from-file)) (template ()) (link_action true))
         ! initializationOptions: unknown key "nope"
         ! oysterlsp.json: hover.maxChars: expected a positive integer, got []
         |}]
@@ -517,7 +629,7 @@ let%test_module "configuration" =
         ~init_options:{|{"dailyNotes": {"folder": "c"}}|};
       [%expect
         {|
-        ((format YYYY-MM-DD) (folder (c)) (template ()))
+        ((format YYYY-MM-DD) (folder (c)) (template ()) (link_action true))
         ! oysterlsp.json: not valid JSON — Line 1, bytes 15-16: Unexpected end of input
         |}]
     ;;

--- a/pkg/oystermark/lsp/lsp_config.ml
+++ b/pkg/oystermark/lsp/lsp_config.ml
@@ -15,7 +15,7 @@ type fragment_behavior =
 
 (** Daily-note settings as written by the client, before validation.  Held as
     strings so {!t} stays comparable; {!daily_notes_settings} turns them into a
-    {!Daily_notes.settings}, or an error when the format is unsupported.
+    {!Daily_notes.type-settings}, or an error when the format is unsupported.
     See {!page-"feature-daily-notes"}. *)
 type daily_notes =
   { format : string

--- a/pkg/oystermark/lsp/lsp_lib.ml
+++ b/pkg/oystermark/lsp/lsp_lib.ml
@@ -11,6 +11,7 @@
 
 module Util = Lsp_util
 module Config = Lsp_config
+module Daily_notes = Daily_notes
 module Link_collect = Link_collect
 module Go_to_definition = Go_to_definition
 module Completion = Completion

--- a/pkg/oystermark/lsp/lsp_lib.ml
+++ b/pkg/oystermark/lsp/lsp_lib.ml
@@ -12,6 +12,7 @@
 module Util = Lsp_util
 module Config = Lsp_config
 module Daily_notes = Daily_notes
+module Command_block = Command_block
 module Link_collect = Link_collect
 module Go_to_definition = Go_to_definition
 module Completion = Completion

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -32,6 +32,11 @@ class oystermark_server ~sw =
            ~codeActionKinds:[ CodeActionKind.QuickFix; CodeActionKind.Refactor ]
            ())
 
+    method! config_code_lens_options : CodeLensOptions.t option =
+      (* Lenses come fully formed, so no [resolveProvider].  See
+         {!page-"feature-command-block"}. *)
+      Some (CodeLensOptions.create ~resolveProvider:false ())
+
     method! config_completion : CompletionOptions.t option =
       (* [[[] opens a wikilink; [#] starts a fragment. See {!page-"feature-completion"}. *)
       Some (CompletionOptions.create ~triggerCharacters:[ "["; "#" ] ())
@@ -93,6 +98,16 @@ class oystermark_server ~sw =
                 ~type_:MessageType.Warning
                 ~message:(sprintf "oystermark: %s" message))));
       super#on_req_initialize ~notify_back params
+
+    method! on_req_code_lens
+      ~notify_back:_
+      ~id:_
+      ~uri
+      ~workDoneToken:_
+      ~partialResultToken:_
+      (_ : Linol_eio.Jsonrpc2.doc_state)
+      : CodeLens.t list =
+      Option.value (Server.code_lens server ~rel_path:(self#rel_path uri)) ~default:[]
 
     (* Document synchronization
        ========================= *)

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -258,8 +258,8 @@ class oystermark_server ~sw =
       match Server.execute_command server ~command ~arguments with
       | None -> `Null
       | Some { uri; create } ->
-        (* Both are fire-and-forget: the client's acknowledgement carries
-           nothing this command needs. *)
+        (* The client's acknowledgement of the edit carries nothing this
+           command needs. *)
         let ignore_response _ = () in
         Option.iter create ~f:(fun edit ->
           let _ =
@@ -269,18 +269,48 @@ class oystermark_server ~sw =
               ignore_response
           in
           ());
+        let created = Option.is_some create in
         if can_show_document
         then (
           let _ =
             notify_back#send_request
               (Linol.Lsp.Server_request.ShowDocumentRequest
                  (ShowDocumentParams.create ~takeFocus:true ~uri ()))
-              ignore_response
+              (function
+                (* A client may advertise the capability and still decline: the
+                 result is the only place that shows up. *)
+                | Ok ({ success = true } : ShowDocumentResult.t) -> ()
+                | Ok _ | Error _ -> self#report_unfocused ~notify_back ~created uri)
           in
-          ());
-        (* A client without [window/showDocument] still gets the note created;
-           the path is the answer it can act on. *)
+          ())
+        else self#report_unfocused ~notify_back ~created uri;
+        (* A client that cannot focus still gets the note created; the path is
+           the answer it can act on. *)
         `String (DocumentUri.to_path uri)
+
+    (** Say that the note was not opened, and where it is.
+
+        Focusing is [window/showDocument]'s job and the one effect the server
+        cannot perform itself.  Where a client does not support it — or
+        declines — the command would otherwise finish in complete silence,
+        indistinguishable from one that failed.  See
+        {!page-"feature-daily-notes".focus}. *)
+    method
+      private report_unfocused
+      ~notify_back
+      ~(created : bool)
+      (uri : DocumentUri.t)
+      : unit =
+      notify_back#send_notification
+        (Linol.Lsp.Server_notification.ShowMessage
+           (ShowMessageParams.create
+              ~type_:MessageType.Info
+              ~message:
+                (sprintf
+                   "oystermark: %s %s — this client cannot open documents on request \
+                    (window/showDocument)"
+                   (if created then "created" else "daily note is at")
+                   (DocumentUri.to_path uri))))
 
     (** [references], [prepareRename] and [rename] have no dedicated hook in
         {!Linol_eio.Jsonrpc2.server}, so they arrive here. *)
@@ -310,7 +340,25 @@ class oystermark_server ~sw =
         | _ -> failwith "unhandled request"
   end
 
-let () =
+(** A starting [oysterlsp.json], on stdout.
+
+    Every key at its default, with the [$schema] association first so the file
+    documents itself in any editor with a JSON language server. The point is a
+    file to edit rather than a file to keep: defaults written down are frozen,
+    and a key left out is a key that follows this server as it changes. See
+    {!page-"feature-configuration".schema-file}. *)
+let print_default_config () : unit =
+  let fields =
+    match Lsp_lib.Config.to_json Lsp_lib.Config.default with
+    | `Assoc fields -> fields
+    | other -> [ "config", other ]
+  in
+  print_endline
+    (Yojson.Safe.pretty_to_string
+       (`Assoc (("$schema", `String Lsp_lib.Config.schema_url) :: fields)))
+;;
+
+let run_server () =
   Eio_main.run
   @@ fun env ->
   let enable_otel = Option.is_some (Sys.getenv "OTEL_EXPORTER_OTLP_ENDPOINT") in
@@ -323,4 +371,12 @@ let () =
   let s = new oystermark_server ~sw in
   let server = Linol_eio.Jsonrpc2.create_stdio ~env s in
   Linol_eio.Jsonrpc2.run server
+;;
+
+(* Anything but the flag starts the server: an editor spawns this with no
+   arguments, and an unrecognized one must not stop it from doing so. *)
+let () =
+  match Sys.get_argv () |> Array.to_list |> List.tl with
+  | Some [ "--print-default-config" ] -> print_default_config ()
+  | _ -> run_server ()
 ;;

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -81,6 +81,17 @@ class oystermark_server ~sw =
       <- (match params.capabilities.window with
           | Some { showDocument = Some { support }; _ } -> support
           | _ -> false);
+      (* A rejected daily-note format is reported here, once.  [showMessage] is
+         one of the few notifications the protocol allows before the
+         [initialize] result, and the alternative — staying quiet — makes a
+         typo look like a missing feature.  See
+         {!page-"feature-daily-notes".format}. *)
+      Option.iter (Server.daily_notes_error server) ~f:(fun message ->
+        notify_back#send_notification
+          (Linol.Lsp.Server_notification.ShowMessage
+             (ShowMessageParams.create
+                ~type_:MessageType.Warning
+                ~message:(sprintf "oystermark: daily notes disabled — %s" message))));
       super#on_req_initialize ~notify_back params
 
     (* Document synchronization

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -13,6 +13,11 @@ class oystermark_server ~sw =
   object (self)
     inherit Linol_eio.Jsonrpc2.server as super
     val server : Server.t = Server.create ()
+
+    (** Whether the client advertised [window/showDocument] at [initialize].
+        Set once, read by the daily-note command. *)
+    val mutable can_show_document : bool = false
+
     method spawn_query_handler f = Linol_eio.spawn ~sw f
     method! config_definition = Some (`Bool true)
     method! config_hover = Some (`Bool true)
@@ -20,8 +25,12 @@ class oystermark_server ~sw =
     method! config_symbol = Some (`Bool true)
 
     method! config_code_action_provider =
+      (* [Refactor] carries the daily-note actions, which no diagnostic
+         underlies. See {!page-"feature-daily-notes"}. *)
       `CodeActionOptions
-        (CodeActionOptions.create ~codeActionKinds:[ CodeActionKind.QuickFix ] ())
+        (CodeActionOptions.create
+           ~codeActionKinds:[ CodeActionKind.QuickFix; CodeActionKind.Refactor ]
+           ())
 
     method! config_completion : CompletionOptions.t option =
       (* [[[] opens a wikilink; [#] starts a fragment. See {!page-"feature-completion"}. *)
@@ -35,6 +44,8 @@ class oystermark_server ~sw =
       ; renameProvider =
           Some (`RenameOptions (RenameOptions.create ~prepareProvider:true ()))
       ; positionEncoding = Some PositionEncodingKind.UTF16
+      ; executeCommandProvider =
+          Some (ExecuteCommandOptions.create ~commands:[ Server.daily_note_command ] ())
       }
 
     method! config_sync_opts : TextDocumentSyncOptions.t =
@@ -59,7 +70,17 @@ class oystermark_server ~sw =
         | Some uri -> Some (DocumentUri.to_path uri)
         | None -> Option.join params.rootPath
       in
-      Option.iter root ~f:(fun root -> Server.initialize server ~root);
+      (* [initializationOptions] is forwarded raw: parsing it, and tolerating a
+         malformed one, is {!Lsp_lib.Config}'s job. *)
+      Option.iter root ~f:(fun root ->
+        Server.initialize server ~root ?init_options:params.initializationOptions ());
+      (* The client tells us here whether it can honor [window/showDocument];
+         the daily-note command degrades when it cannot. See
+         {!page-"feature-daily-notes"}. *)
+      can_show_document
+      <- (match params.capabilities.window with
+          | Some { showDocument = Some { support }; _ } -> support
+          | _ -> false);
       super#on_req_initialize ~notify_back params
 
     (* Document synchronization
@@ -196,7 +217,7 @@ class oystermark_server ~sw =
         {!Linol_eio.Jsonrpc2.server}, so they arrive here. *)
     method! on_request_unhandled
       : type r. notify_back:_ -> id:_ -> r Linol.Lsp.Client_request.t -> r =
-      fun ~notify_back:_ ~id:_ (req : r Linol.Lsp.Client_request.t) ->
+      fun ~notify_back ~id:_ (req : r Linol.Lsp.Client_request.t) ->
         match req with
         | Linol.Lsp.Client_request.TextDocumentReferences params ->
           Server.references
@@ -217,7 +238,47 @@ class oystermark_server ~sw =
             ~line:params.position.line
             ~character:params.position.character
             ~new_name:params.newName
+        | Linol.Lsp.Client_request.ExecuteCommand params ->
+          self#execute_command ~notify_back ~params
         | _ -> failwith "unhandled request"
+
+    (** Run a server command.  The decision of {i what} to do is
+        {!Lsp_lib.Server.execute_command}'s; this only turns the resulting
+        {!Lsp_lib.Server.open_note} into the two protocol effects — create the
+        file, then focus it.  See {!page-"feature-daily-notes"}. *)
+    method
+      private execute_command
+      ~notify_back
+      ~(params : ExecuteCommandParams.t)
+      : Yojson.Safe.t =
+      match
+        Server.execute_command server ~command:params.command ~arguments:params.arguments
+      with
+      | None -> `Null
+      | Some { uri; create } ->
+        (* Both are fire-and-forget: the client's acknowledgement carries
+           nothing this command needs. *)
+        let ignore_response _ = () in
+        Option.iter create ~f:(fun edit ->
+          let _ =
+            notify_back#send_request
+              (Linol.Lsp.Server_request.WorkspaceApplyEdit
+                 (ApplyWorkspaceEditParams.create ~edit ()))
+              ignore_response
+          in
+          ());
+        if can_show_document
+        then (
+          let _ =
+            notify_back#send_request
+              (Linol.Lsp.Server_request.ShowDocumentRequest
+                 (ShowDocumentParams.create ~takeFocus:true ~uri ()))
+              ignore_response
+          in
+          ());
+        (* A client without [window/showDocument] still gets the note created;
+           the path is the answer it can act on. *)
+        `String (DocumentUri.to_path uri)
   end
 
 let () =

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -81,17 +81,17 @@ class oystermark_server ~sw =
       <- (match params.capabilities.window with
           | Some { showDocument = Some { support }; _ } -> support
           | _ -> false);
-      (* A rejected daily-note format is reported here, once.  [showMessage] is
-         one of the few notifications the protocol allows before the
-         [initialize] result, and the alternative — staying quiet — makes a
-         typo look like a missing feature.  See
-         {!page-"feature-daily-notes".format}. *)
-      Option.iter (Server.daily_notes_error server) ~f:(fun message ->
+      (* Anything the configuration asked for and could not have is reported
+         here, once.  [showMessage] is one of the few notifications the
+         protocol allows before the [initialize] result, and the alternative —
+         staying quiet — makes a mistyped setting look like a missing feature.
+         See {!page-"feature-configuration".tolerance}. *)
+      List.iter (Server.config_warnings server) ~f:(fun message ->
         notify_back#send_notification
           (Linol.Lsp.Server_notification.ShowMessage
              (ShowMessageParams.create
                 ~type_:MessageType.Warning
-                ~message:(sprintf "oystermark: daily notes disabled — %s" message))));
+                ~message:(sprintf "oystermark: %s" message))));
       super#on_req_initialize ~notify_back params
 
     (* Document synchronization

--- a/pkg/oystermark/lsp/main.ml
+++ b/pkg/oystermark/lsp/main.ml
@@ -239,47 +239,23 @@ class oystermark_server ~sw =
         ~start_line:range.start.line
         ~end_line:range.end_.line
 
-    (** [references], [prepareRename] and [rename] have no dedicated hook in
-        {!Linol_eio.Jsonrpc2.server}, so they arrive here. *)
-    method! on_request_unhandled
-      : type r. notify_back:_ -> id:_ -> r Linol.Lsp.Client_request.t -> r =
-      fun ~notify_back ~id:_ (req : r Linol.Lsp.Client_request.t) ->
-        match req with
-        | Linol.Lsp.Client_request.TextDocumentReferences params ->
-          Server.references
-            server
-            ~rel_path:(self#rel_path params.textDocument.uri)
-            ~line:params.position.line
-            ~character:params.position.character
-        | Linol.Lsp.Client_request.TextDocumentPrepareRename params ->
-          Server.prepare_rename
-            server
-            ~rel_path:(self#rel_path params.textDocument.uri)
-            ~line:params.position.line
-            ~character:params.position.character
-        | Linol.Lsp.Client_request.TextDocumentRename params ->
-          Server.rename
-            server
-            ~rel_path:(self#rel_path params.textDocument.uri)
-            ~line:params.position.line
-            ~character:params.position.character
-            ~new_name:params.newName
-        | Linol.Lsp.Client_request.ExecuteCommand params ->
-          self#execute_command ~notify_back ~params
-        | _ -> failwith "unhandled request"
-
     (** Run a server command.  The decision of {i what} to do is
         {!Lsp_lib.Server.execute_command}'s; this only turns the resulting
         {!Lsp_lib.Server.open_note} into the two protocol effects — create the
-        file, then focus it.  See {!page-"feature-daily-notes"}. *)
-    method
-      private execute_command
+        file, then focus it.  See {!page-"feature-daily-notes"}.
+
+        This overrides the dedicated hook rather than answering in
+        {!on_request_unhandled}: [ExecuteCommand] is dispatched to
+        [on_req_execute_command] before the unhandled path is consulted, so a
+        branch there would never run. *)
+    method! on_req_execute_command
       ~notify_back
-      ~(params : ExecuteCommandParams.t)
+      ~id:_
+      ~workDoneToken:_
+      (command : string)
+      (arguments : Yojson.Safe.t list option)
       : Yojson.Safe.t =
-      match
-        Server.execute_command server ~command:params.command ~arguments:params.arguments
-      with
+      match Server.execute_command server ~command ~arguments with
       | None -> `Null
       | Some { uri; create } ->
         (* Both are fire-and-forget: the client's acknowledgement carries
@@ -305,6 +281,33 @@ class oystermark_server ~sw =
         (* A client without [window/showDocument] still gets the note created;
            the path is the answer it can act on. *)
         `String (DocumentUri.to_path uri)
+
+    (** [references], [prepareRename] and [rename] have no dedicated hook in
+        {!Linol_eio.Jsonrpc2.server}, so they arrive here. *)
+    method! on_request_unhandled
+      : type r. notify_back:_ -> id:_ -> r Linol.Lsp.Client_request.t -> r =
+      fun ~notify_back ~id:_ (req : r Linol.Lsp.Client_request.t) ->
+        match req with
+        | Linol.Lsp.Client_request.TextDocumentReferences params ->
+          Server.references
+            server
+            ~rel_path:(self#rel_path params.textDocument.uri)
+            ~line:params.position.line
+            ~character:params.position.character
+        | Linol.Lsp.Client_request.TextDocumentPrepareRename params ->
+          Server.prepare_rename
+            server
+            ~rel_path:(self#rel_path params.textDocument.uri)
+            ~line:params.position.line
+            ~character:params.position.character
+        | Linol.Lsp.Client_request.TextDocumentRename params ->
+          Server.rename
+            server
+            ~rel_path:(self#rel_path params.textDocument.uri)
+            ~line:params.position.line
+            ~character:params.position.character
+            ~new_name:params.newName
+        | _ -> failwith "unhandled request"
   end
 
 let () =

--- a/pkg/oystermark/lsp/oysterlsp.schema.json
+++ b/pkg/oystermark/lsp/oysterlsp.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/hon-gyu/oyster/main/pkg/oystermark/lsp/oysterlsp.schema.json",
+  "title": "oysterlsp.json",
+  "description": "Configuration for the Oystermark language server, read from oysterlsp.json at the vault root. Every setting also has an initializationOptions equivalent, which this file overrides key by key. Anything unusable falls back to the default and is reported at startup rather than failing.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Association to this schema, so an editor's JSON language server offers completion and validation here. Not a setting."
+    },
+    "dailyNotes": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Where daily notes live and how they are named. See the daily-notes feature spec.",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "YYYY-MM-DD",
+          "description": "Date format naming the note, as a subset of the moment.js tokens (YYYY, MM, DD, MMM, MMMM, ddd, dddd, and [literal] text). May contain '/' to nest notes in folders. An unsupported format disables the daily-note actions entirely and is reported at startup.",
+          "examples": [
+            "YYYY-MM-DD",
+            "YYYY/MM/YYYY-MM-DD",
+            "YYYY-MM-DD dddd"
+          ]
+        },
+        "folder": {
+          "type": "string",
+          "description": "Vault-relative folder the daily notes live under. Omit for the vault root.",
+          "examples": [
+            "journal",
+            "daily"
+          ]
+        },
+        "template": {
+          "type": "string",
+          "description": "Stubbed: the setting round-trips but note creation always makes an empty note."
+        },
+        "linkAction": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to offer the 'Insert link to today's daily note' code action. It is the only daily-note action offered in every menu in the vault, and the only one that reaches its note without window/showDocument — so turning it off in a client lacking that capability gives up reaching daily notes altogether."
+        }
+      }
+    },
+    "hover": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxChars": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "default": 2000,
+          "description": "Bytes of note content a hover may include. Content past the limit is truncated at the previous newline, with a '*(truncated)*' suffix."
+        }
+      }
+    },
+    "goToDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unresolvedFragment": {
+          "enum": [
+            "fallback",
+            "strict"
+          ],
+          "default": "fallback",
+          "description": "What to do with a link whose file exists but whose heading or block-id fragment does not. 'fallback' jumps to the top of the file; 'strict' returns no result."
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unresolvedFragment": {
+          "enum": [
+            "fallback",
+            "strict"
+          ],
+          "default": "fallback",
+          "description": "What to do with a link whose file exists but whose fragment does not. 'fallback' warns about nothing; 'strict' reports the fragment as unresolved."
+        }
+      }
+    }
+  }
+}

--- a/pkg/oystermark/lsp/rename.ml
+++ b/pkg/oystermark/lsp/rename.ml
@@ -161,7 +161,7 @@ let find_definition_line content target =
             String.lstrip text ~drop:(Char.equal '#')
             |> String.lstrip ~drop:(Char.equal ' ')
           in
-          String.equal (Oystermark.Parse.Heading_slug.slugify heading) slug)
+          String.equal (Oystermark.Parse.Common.heading_id_of_text heading) slug)
       | Path_block { block_id; _ } ->
         Option.equal String.equal (Find_references.block_id_of_line text) (Some block_id)
       | Path_attr { id; _ } -> Option.is_some (attr_id_offset ~id text)

--- a/pkg/oystermark/lsp/scripts/smoke.py
+++ b/pkg/oystermark/lsp/scripts/smoke.py
@@ -57,6 +57,7 @@ class Session:
         self.stdout: IO[bytes] = self.proc.stdout
         self.root = root
         self.requests = []  # methods the server sent us, in order
+        self.messages = []  # window/showMessage texts, in order
         self.next_id = 1
 
     def send(self, msg):
@@ -98,6 +99,8 @@ class Session:
                     else {"success": True}
                 )
                 self.send({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+            elif msg.get("method") == "window/showMessage":
+                self.messages.append(msg["params"]["message"])
             elif msg.get("id") == id_:
                 if "error" in msg:
                     raise RuntimeError(f"{method} failed: {msg['error']}")
@@ -128,7 +131,7 @@ def check(label, ok, detail="", hint=""):
         failures.append(label)
 
 
-def run(binary):
+def run(binary, show_document=True):
     root = tempfile.mkdtemp(prefix="oysterlsp-smoke-")
     with open(os.path.join(root, NOTE), "w") as f:
         f.write(NOTE_TEXT)
@@ -137,12 +140,13 @@ def run(binary):
     try:
         # A bare vault: no oysterlsp.json, no initializationOptions.  Daily
         # notes must still work off their defaults.
+        window = {"showDocument": {"support": True}} if show_document else {}
         caps = s.request(
             "initialize",
             {
                 "processId": None,
                 "rootUri": "file://" + root,
-                "capabilities": {"window": {"showDocument": {"support": True}}},
+                "capabilities": {"window": window},
             },
         )["capabilities"]
 
@@ -197,7 +201,7 @@ def run(binary):
         if daily is None:
             check("a code action carries a command", False)
         else:
-            before = len(s.requests)
+            before, said = len(s.requests), len(s.messages)
             result = s.request(
                 "workspace/executeCommand",
                 {
@@ -205,7 +209,7 @@ def run(binary):
                     "arguments": daily["command"]["arguments"],
                 },
             )
-            sent = s.requests[before:]
+            sent, messages = s.requests[before:], s.messages[said:]
             check(
                 "reaches the handler (result is not null)",
                 result is not None,
@@ -213,7 +217,21 @@ def run(binary):
                 "not overridden — check which linol method handles it",
             )
             check("sends workspace/applyEdit", "workspace/applyEdit" in sent)
-            check("sends window/showDocument", "window/showDocument" in sent)
+            if show_document:
+                check("sends window/showDocument", "window/showDocument" in sent)
+                check("stays quiet when the client can focus", not messages)
+            else:
+                # Where focusing is impossible the command must still say so:
+                # silence is indistinguishable from failure.
+                check(
+                    "does not send window/showDocument",
+                    "window/showDocument" not in sent,
+                )
+                check(
+                    "reports the path instead",
+                    any(root in m for m in messages),
+                    f"said {messages}",
+                )
 
         # Code lenses carry the same commands; a client that renders them is
         # the whole point of the command block.
@@ -246,7 +264,12 @@ if __name__ == "__main__":
             f"no such binary: {binary}\n(build it with: dune build {DEFAULT_BINARY})"
         )
     print(f"smoke-checking {binary}")
+    print("\n### client that supports window/showDocument")
     run(binary)
+    # The other half of the world, and the one several editors are in: the
+    # command cannot focus, and must say so rather than finish in silence.
+    print("\n### client that does not support window/showDocument")
+    run(binary, show_document=False)
     print(
         f"\n{len(failures)} failure(s)"
         + (": " + ", ".join(failures) if failures else "")

--- a/pkg/oystermark/lsp/scripts/smoke.py
+++ b/pkg/oystermark/lsp/scripts/smoke.py
@@ -1,0 +1,254 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# type: ignore
+"""Smoke-check the LSP adapter over a real stdio session.
+
+`tests/lsp/` drives `Lsp_lib.Server` in process, which leaves `main.ml` —
+capability advertisement and request dispatch — uncovered.  That gap is not
+theoretical: the daily-note command was once handled in `on_request_unhandled`,
+which linol never consults for `ExecuteCommand`, so a correct handler sat
+unreachable while every test passed.  Nothing in the suite could see it,
+because the bug was in which hook the handler hung off.
+
+This script talks to the built binary the way an editor does and asserts the
+effects an editor would observe.  Run it by hand after touching `main.ml`:
+
+    dune build pkg/oystermark/lsp/main.exe
+    uv run --script pkg/oystermark/lsp/scripts/smoke.py
+
+Pass a path to check a different binary — the installed one, say:
+
+    uv run --script pkg/oystermark/lsp/scripts/smoke.py $(which oystermark-lsp)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import IO
+
+DEFAULT_BINARY = "_build/default/pkg/oystermark/lsp/main.exe"
+DAILY_NOTE_COMMAND = "oystermark.dailyNote.open"
+
+NOTE = "note.md"
+NOTE_TEXT = "# Hello\n\nsome prose.\n"
+
+
+# Session
+# =======
+
+
+class Session:
+    """One stdio LSP session, with the server's own requests recorded."""
+
+    def __init__(self, binary, root):
+        self.proc = subprocess.Popen(
+            [binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        assert self.proc.stdin is not None and self.proc.stdout is not None
+        self.stdin: IO[bytes] = self.proc.stdin
+        self.stdout: IO[bytes] = self.proc.stdout
+        self.root = root
+        self.requests = []  # methods the server sent us, in order
+        self.next_id = 1
+
+    def send(self, msg):
+        body = json.dumps(msg).encode()
+        self.stdin.write(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+        self.stdin.flush()
+
+    def read(self):
+        length = None
+        while True:
+            line = self.stdout.readline()
+            if not line:
+                return None
+            line = line.strip()
+            if not line:
+                break
+            if line.lower().startswith(b"content-length:"):
+                length = int(line.split(b":")[1])
+        if length is None:
+            return None
+        return json.loads(self.stdout.read(length))
+
+    def request(self, method, params):
+        """Send a request and pump until its response, acking anything the
+        server asks of us on the way — a server request left unanswered can
+        stall the exchange being measured."""
+        id_ = self.next_id
+        self.next_id += 1
+        self.send({"jsonrpc": "2.0", "id": id_, "method": method, "params": params})
+        while True:
+            msg = self.read()
+            if msg is None:
+                raise RuntimeError(f"server closed the connection during {method}")
+            if "method" in msg and msg.get("id") is not None:
+                self.requests.append(msg["method"])
+                result = (
+                    {"applied": True}
+                    if msg["method"] == "workspace/applyEdit"
+                    else {"success": True}
+                )
+                self.send({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+            elif msg.get("id") == id_:
+                if "error" in msg:
+                    raise RuntimeError(f"{method} failed: {msg['error']}")
+                return msg.get("result")
+
+    def notify(self, method, params):
+        self.send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def uri(self, rel_path):
+        return "file://" + os.path.join(self.root, rel_path)
+
+    def close(self):
+        self.proc.kill()
+
+
+# Checks
+# ======
+
+failures = []
+
+
+def check(label, ok, detail="", hint=""):
+    """[detail] is context worth seeing either way; [hint] is guidance that
+    only matters once the check has failed."""
+    note = detail or (hint if not ok else "")
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{'  — ' + note if note else ''}")
+    if not ok:
+        failures.append(label)
+
+
+def run(binary):
+    root = tempfile.mkdtemp(prefix="oysterlsp-smoke-")
+    with open(os.path.join(root, NOTE), "w") as f:
+        f.write(NOTE_TEXT)
+
+    s = Session(binary, root)
+    try:
+        # A bare vault: no oysterlsp.json, no initializationOptions.  Daily
+        # notes must still work off their defaults.
+        caps = s.request(
+            "initialize",
+            {
+                "processId": None,
+                "rootUri": "file://" + root,
+                "capabilities": {"window": {"showDocument": {"support": True}}},
+            },
+        )["capabilities"]
+
+        print("\ncapabilities")
+        check("codeActionProvider", caps.get("codeActionProvider") is not None)
+        check("codeLensProvider", caps.get("codeLensProvider") is not None)
+        commands = (caps.get("executeCommandProvider") or {}).get("commands", [])
+        check(
+            "executeCommandProvider lists the daily-note command",
+            DAILY_NOTE_COMMAND in commands,
+            f"got {commands}",
+        )
+
+        s.notify("initialized", {})
+        s.notify(
+            "textDocument/didOpen",
+            {
+                "textDocument": {
+                    "uri": s.uri(NOTE),
+                    "languageId": "markdown",
+                    "version": 1,
+                    "text": NOTE_TEXT,
+                }
+            },
+        )
+
+        # Code actions: the daily-note menu, plus the command block offer.
+        print("\ntextDocument/codeAction")
+        actions = s.request(
+            "textDocument/codeAction",
+            {
+                "textDocument": {"uri": s.uri(NOTE)},
+                "range": {
+                    "start": {"line": 2, "character": 0},
+                    "end": {"line": 2, "character": 0},
+                },
+                "context": {"diagnostics": []},
+            },
+        )
+        titles = [a["title"] for a in actions]
+        check("daily-note actions offered", any("daily note" in t for t in titles))
+        check(
+            "command-block insert offered",
+            any("command block" in t for t in titles),
+            f"got {titles}",
+        )
+
+        # The seam that had no coverage: a command must reach the handler and
+        # produce its two protocol effects.
+        print("\nworkspace/executeCommand")
+        daily = next((a for a in actions if a.get("command")), None)
+        if daily is None:
+            check("a code action carries a command", False)
+        else:
+            before = len(s.requests)
+            result = s.request(
+                "workspace/executeCommand",
+                {
+                    "command": daily["command"]["command"],
+                    "arguments": daily["command"]["arguments"],
+                },
+            )
+            sent = s.requests[before:]
+            check(
+                "reaches the handler (result is not null)",
+                result is not None,
+                hint="null means the request was dispatched to a hook that is "
+                "not overridden — check which linol method handles it",
+            )
+            check("sends workspace/applyEdit", "workspace/applyEdit" in sent)
+            check("sends window/showDocument", "window/showDocument" in sent)
+
+        # Code lenses carry the same commands; a client that renders them is
+        # the whole point of the command block.
+        print("\ntextDocument/codeLens")
+        panel = "```oysterlsp\ndaily/today\n```\n"
+        s.notify(
+            "textDocument/didChange",
+            {
+                "textDocument": {"uri": s.uri(NOTE), "version": 2},
+                "contentChanges": [{"text": NOTE_TEXT + "\n" + panel}],
+            },
+        )
+        lenses = s.request(
+            "textDocument/codeLens", {"textDocument": {"uri": s.uri(NOTE)}}
+        )
+        check(
+            "a command-block line gets a lens with a command",
+            any(lens.get("command", {}).get("command") for lens in lenses),
+            f"got {len(lenses)} lens(es)",
+        )
+    finally:
+        s.close()
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    binary = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_BINARY
+    if not os.path.exists(binary):
+        sys.exit(
+            f"no such binary: {binary}\n(build it with: dune build {DEFAULT_BINARY})"
+        )
+    print(f"smoke-checking {binary}")
+    run(binary)
+    print(
+        f"\n{len(failures)} failure(s)"
+        + (": " + ", ".join(failures) if failures else "")
+    )
+    sys.exit(1 if failures else 0)

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -670,6 +670,53 @@ let command_block_actions (t : t) ~(rel_path : string) ~(line : int) : CodeActio
        ])
 ;;
 
+(** The action that seeds a note with a panel of its own, at the cursor's line.
+
+    Offered only where there is no block yet, and listing only the commands
+    that can run in {e this} note — an ordinary note gets the calendar three,
+    a daily note with neighbours gets all five.  Inserting the whole catalogue
+    everywhere would hand most notes two lines the lenses immediately report as
+    dead.  See {!page-"feature-command-block".insert}. *)
+let insert_command_block_actions (t : t) ~(rel_path : string) ~(line : int)
+  : CodeAction.t list
+  =
+  let content = buffer_content t rel_path in
+  if Command_block.has_command_block content
+  then []
+  else (
+    match
+      List.filter Command_block.all_of_command ~f:(fun c ->
+        Option.is_some (resolve_command t ~rel_path c).target)
+    with
+    (* Nothing runs here — daily notes are off — so there is no panel worth
+       writing. *)
+    | [] -> []
+    | commands ->
+      let at = Position.create ~line ~character:0 in
+      [ CodeAction.create
+          ~title:"Insert oysterlsp command block"
+          ~kind:CodeActionKind.Refactor
+          ~edit:
+            (WorkspaceEdit.create
+               ~documentChanges:
+                 [ `TextDocumentEdit
+                     (TextDocumentEdit.create
+                        ~textDocument:
+                          (OptionalVersionedTextDocumentIdentifier.create
+                             ~uri:(uri_of_rel_path t rel_path)
+                             ())
+                        ~edits:
+                          [ `TextEdit
+                              (TextEdit.create
+                                 ~range:(Range.create ~start:at ~end_:at)
+                                 ~newText:(Command_block.render commands))
+                          ])
+                 ]
+               ())
+          ()
+      ])
+;;
+
 (** The catalogue, offered inside a command block and nowhere else. *)
 let command_block_completions (t : t) ~(rel_path : string) ~(line : int)
   : CompletionItem.t list option
@@ -744,7 +791,9 @@ let code_action
          whole daily-note menu would bury it.  See
          {!page-"feature-command-block".surfaces}. *)
       match command_block_actions t ~rel_path ~line:start_line with
-      | [] -> daily_note_actions t ~rel_path
+      | [] ->
+        daily_note_actions t ~rel_path
+        @ insert_command_block_actions t ~rel_path ~line:start_line
       | actions -> actions)
     else []
   in

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -544,6 +544,68 @@ let daily_note_actions (t : t) ~(rel_path : string) : CodeAction.t list =
     calendar @ existing
 ;;
 
+(** Write a wikilink to today's daily note at the cursor, creating the note
+    when it is missing.
+
+    Every other action in the family reaches its note through
+    [window/showDocument], which the protocol makes optional and not every
+    client implements.  This one asks for nothing but a [WorkspaceEdit], and
+    leaves behind a link that go-to-definition follows — so the note stays
+    reachable wherever that capability is missing.  It is also, independently,
+    an ordinary thing to want in a note.
+
+    The link is the note's base name: [resolve_file] matches a path
+    subsequence, so [ [[2026-07-26]] ] finds [2026/07/2026-07-26.md] under a
+    nested format without the writer spelling out the folders.  See
+    {!page-"feature-daily-notes".link}. *)
+let daily_note_link_actions (t : t) ~(rel_path : string) ~(line : int) ~(character : int)
+  : CodeAction.t list
+  =
+  match daily_table t with
+  | Error _ -> []
+  (* Unlike the rest of the family this one is offered in every menu in the
+     vault, wanted there or not, so it is the one worth being able to turn off
+     without disabling daily notes.  See {!page-"feature-daily-notes".link}. *)
+  | Ok _ when not t.config.daily_notes.link_action -> []
+  | Ok table ->
+    let path = Daily_notes.path_of_date table.Daily_notes.Table.settings (t.now ()) in
+    let name = Filename.chop_extension (Filename.basename path) in
+    let create =
+      if file_exists t path
+      then []
+      else
+        [ `CreateFile
+            (CreateFile.create
+               ~uri:(uri_of_rel_path t path)
+               ~options:
+                 (CreateFileOptions.create ~ignoreIfExists:true ~overwrite:false ())
+               ())
+        ]
+    in
+    let at = Position.create ~line ~character in
+    let insert =
+      `TextDocumentEdit
+        (TextDocumentEdit.create
+           ~textDocument:
+             (OptionalVersionedTextDocumentIdentifier.create
+                ~uri:(uri_of_rel_path t rel_path)
+                ())
+           ~edits:
+             [ `TextEdit
+                 (TextEdit.create
+                    ~range:(Range.create ~start:at ~end_:at)
+                    ~newText:(sprintf "[[%s]]" name))
+             ])
+    in
+    (* Creation first: the link should resolve the moment it is written. *)
+    [ CodeAction.create
+        ~title:"Insert link to today's daily note"
+        ~kind:CodeActionKind.Refactor
+        ~edit:(WorkspaceEdit.create ~documentChanges:(create @ [ insert ]) ())
+        ()
+    ]
+;;
+
 (* Command blocks
    ===============
 
@@ -793,6 +855,7 @@ let code_action
       match command_block_actions t ~rel_path ~line:start_line with
       | [] ->
         daily_note_actions t ~rel_path
+        @ daily_note_link_actions t ~rel_path ~line:start_line ~character:start_character
         @ insert_command_block_actions t ~rel_path ~line:start_line
       | actions -> actions)
     else []

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -38,6 +38,11 @@ type t =
           disk.  See {!page-"feature-document-sync"}. *)
   ; mutable config : Lsp_config.t
     (** Client-supplied settings, seen once at {!initialize}. *)
+  ; mutable daily_notes_error : string option
+    (** Why the configured daily-note format was rejected, if it was.  Kept so
+          that {!initialize} can hand it to the adapter: a rejection the user
+          never sees is indistinguishable from the feature being absent.  See
+          {!page-"feature-daily-notes".format}. *)
   ; mutable daily_table : (Date.t * Daily_notes.Table.t) option
     (** Memoized recognition table with the date it was built for; a server
           left running overnight rebuilds it.  See
@@ -57,6 +62,7 @@ let create ?(now : unit -> Date.t = system_today) () : t =
   { vault = None
   ; open_docs = String.Table.create ()
   ; config = Lsp_config.default
+  ; daily_notes_error = None
   ; daily_table = None
   ; now
   }
@@ -64,6 +70,7 @@ let create ?(now : unit -> Date.t = system_today) () : t =
 
 let initialize (t : t) ~(root : string) ?(init_options : Yojson.Safe.t option) () : unit =
   t.config <- Lsp_config.of_initialization_options init_options;
+  t.daily_notes_error <- Result.error (Lsp_config.daily_notes_settings t.config);
   t.daily_table <- None;
   t.vault <- Some (build_vault root)
 ;;
@@ -392,6 +399,12 @@ let document_symbol (t : t) ~(rel_path : string) : DocumentSymbol.t list option 
     an editor by itself, so the action defers to this command, which the client
     sends back as [workspace/executeCommand]. *)
 let daily_note_command = "oystermark.dailyNote.open"
+
+(** Why the daily-note actions are unavailable, when a rejected format is the
+    reason.  The adapter shows this once at [initialize]; without it, a typo'd
+    format and an unconfigured feature look identical from the editor.  See
+    {!page-"feature-daily-notes".format}. *)
+let daily_notes_error (t : t) : string option = t.daily_notes_error
 
 (** What {!execute_command} decided should happen.  Returning an intent rather
     than performing it keeps the protocol effects — [workspace/applyEdit] and

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -38,11 +38,11 @@ type t =
           disk.  See {!page-"feature-document-sync"}. *)
   ; mutable config : Lsp_config.t
     (** Client-supplied settings, seen once at {!initialize}. *)
-  ; mutable daily_notes_error : string option
-    (** Why the configured daily-note format was rejected, if it was.  Kept so
-          that {!initialize} can hand it to the adapter: a rejection the user
-          never sees is indistinguishable from the feature being absent.  See
-          {!page-"feature-daily-notes".format}. *)
+  ; mutable config_warnings : string list
+    (** Everything the configuration sources asked for and could not have,
+          gathered at {!initialize} for the adapter to report.  A setting
+          ignored in silence is indistinguishable from one that does not
+          exist.  See {!page-"feature-configuration".tolerance}. *)
   ; mutable daily_table : (Date.t * Daily_notes.Table.t) option
     (** Memoized recognition table with the date it was built for; a server
           left running overnight rebuilds it.  See
@@ -62,18 +62,33 @@ let create ?(now : unit -> Date.t = system_today) () : t =
   { vault = None
   ; open_docs = String.Table.create ()
   ; config = Lsp_config.default
-  ; daily_notes_error = None
+  ; config_warnings = []
   ; daily_table = None
   ; now
   }
 ;;
 
 let initialize (t : t) ~(root : string) ?(init_options : Yojson.Safe.t option) () : unit =
-  t.config <- Lsp_config.of_initialization_options init_options;
-  t.daily_notes_error <- Result.error (Lsp_config.daily_notes_settings t.config);
+  let config, warnings = Lsp_config.load ~root ~init_options in
+  t.config <- config;
+  (* The daily-note format is validated here rather than at parse time — it is
+     the one setting whose usability is a property of its {e value} — but it
+     joins the same list, so the user hears about it the same way. *)
+  let daily_notes_warning =
+    match Lsp_config.daily_notes_settings config with
+    | Ok _ -> []
+    | Error e -> [ sprintf "daily notes disabled: %s" e ]
+  in
+  t.config_warnings <- warnings @ daily_notes_warning;
   t.daily_table <- None;
   t.vault <- Some (build_vault root)
 ;;
+
+(** What the configuration sources asked for and could not have.  Empty when
+    the configuration is clean; meaningful only after {!initialize}, which is
+    also the only time it is computed.  See
+    {!page-"feature-configuration".tolerance}. *)
+let config_warnings (t : t) : string list = t.config_warnings
 
 let rebuild_vault (t : t) : unit =
   match t.vault with
@@ -399,12 +414,6 @@ let document_symbol (t : t) ~(rel_path : string) : DocumentSymbol.t list option 
     an editor by itself, so the action defers to this command, which the client
     sends back as [workspace/executeCommand]. *)
 let daily_note_command = "oystermark.dailyNote.open"
-
-(** Why the daily-note actions are unavailable, when a rejected format is the
-    reason.  The adapter shows this once at [initialize]; without it, a typo'd
-    format and an unconfigured feature look identical from the editor.  See
-    {!page-"feature-daily-notes".format}. *)
-let daily_notes_error (t : t) : string option = t.daily_notes_error
 
 (** What {!execute_command} decided should happen.  Returning an intent rather
     than performing it keeps the protocol effects — [workspace/applyEdit] and

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -158,18 +158,52 @@ let byte_of_position (content : string) ~(line : int) ~(character : int) : int =
 (* Document synchronization
    ========================= *)
 
+(** Every line of a command block that names nothing.  A misspelling would
+    otherwise be inert, and inert looks exactly like unimplemented. *)
+let command_block_diagnostics (content : string) : Diagnostic.t list =
+  Command_block.entries content
+  |> List.filter_map ~f:(fun (e : Command_block.entry) ->
+    match e.command with
+    | Some _ -> None
+    | None ->
+      let line_start = Lsp_util.line_start_byte content ~line:e.line in
+      Some
+        (Diagnostic.create
+           ~range:
+             (range_of_bytes
+                content
+                ~first_byte:line_start
+                ~last_byte:(line_start + String.length e.text))
+           ~severity:DiagnosticSeverity.Warning
+           ~source:"oystermark"
+           ~message:
+             (`String
+                 (sprintf
+                    "unknown oysterlsp command %S; expected one of %s"
+                    e.text
+                    (String.concat
+                       ~sep:", "
+                       (List.map
+                          Command_block.all_of_command
+                          ~f:Command_block.name_of_command))))
+           ()))
+;;
+
 let diagnostics (t : t) ~(rel_path : string) ~(content : string) : Diagnostic.t list =
   match t.vault with
   | None -> []
   | Some v ->
-    Feature.Diagnostics.compute ~index:v.index ~rel_path ~content ()
-    |> List.map ~f:(fun (d : Feature.Diagnostics.diagnostic) ->
-      Diagnostic.create
-        ~range:(range_of_bytes content ~first_byte:d.first_byte ~last_byte:d.last_byte)
-        ~severity:DiagnosticSeverity.Warning
-        ~source:"oystermark"
-        ~message:(`String d.message)
-        ())
+    let links =
+      Feature.Diagnostics.compute ~index:v.index ~rel_path ~content ()
+      |> List.map ~f:(fun (d : Feature.Diagnostics.diagnostic) ->
+        Diagnostic.create
+          ~range:(range_of_bytes content ~first_byte:d.first_byte ~last_byte:d.last_byte)
+          ~severity:DiagnosticSeverity.Warning
+          ~source:"oystermark"
+          ~message:(`String d.message)
+          ())
+    in
+    links @ command_block_diagnostics content
 ;;
 
 let did_open (t : t) ~(rel_path : string) ~(content : string) : Diagnostic.t list =
@@ -510,6 +544,152 @@ let daily_note_actions (t : t) ~(rel_path : string) : CodeAction.t list =
     calendar @ existing
 ;;
 
+(* Command blocks
+   ===============
+
+   See {!page-"feature-command-block"}.  Nothing new happens here: a block line
+   is another way to reach the daily-note command, lifted from the code-action
+   menu onto a line where a lens can render it. *)
+
+(** What a command-block line amounts to right now, in this note.  [target] is
+    [None] when the command is understood but cannot run — then [label] says
+    why, and the surfaces show it without anything to click. *)
+type resolved_command =
+  { label : string
+  ; target : (string * bool) option (** [(path, create_it)]. *)
+  }
+
+let resolve_command (t : t) ~(rel_path : string) (c : Command_block.command)
+  : resolved_command
+  =
+  match daily_table t with
+  | Error _ -> { label = "daily notes disabled"; target = None }
+  | Ok table ->
+    let settings = table.Daily_notes.Table.settings in
+    let today = t.now () in
+    (* Calendar commands always have a target: a missing note is created. *)
+    let calendar (what : string) (date : Date.t) =
+      let path = Daily_notes.path_of_date settings date in
+      let exists = file_exists t path in
+      { label = sprintf "%s %s daily note" (if exists then "Open" else "Create") what
+      ; target = Some (path, not exists)
+      }
+    in
+    (* Previous/next answer relative to the {e host} note, which is why the
+       block lives in a note.  Neither ever creates. *)
+    let step (what : string) f =
+      match Daily_notes.Table.date_of_path table rel_path with
+      | None ->
+        { label = sprintf "no %s daily note: this note is not one" what; target = None }
+      | Some date ->
+        (match f table ~exists:(fun p -> file_exists t p) date with
+         | None -> { label = sprintf "no %s daily note" what; target = None }
+         | Some (_, path) ->
+           { label = sprintf "Open %s daily note (%s)" what path
+           ; target = Some (path, false)
+           })
+    in
+    (match c with
+     | Daily_today -> calendar "today's" today
+     | Daily_yesterday -> calendar "yesterday's" (Date.add_days today (-1))
+     | Daily_tomorrow -> calendar "tomorrow's" (Date.add_days today 1)
+     | Daily_prev -> step "previous" Daily_notes.Table.previous_existing
+     | Daily_next -> step "next" Daily_notes.Table.next_existing)
+;;
+
+(** The lens for one line: a whole-line range, the resolved label, and the
+    command when there is one to run. *)
+let lens_of_entry
+      (t : t)
+      ~(rel_path : string)
+      ~(content : string)
+      (e : Command_block.entry)
+  : CodeLens.t option
+  =
+  match e.command with
+  (* An unknown name gets a diagnostic instead; a lens saying nothing useful
+     would only compete with it. *)
+  | None -> None
+  | Some c ->
+    let { label; target } = resolve_command t ~rel_path c in
+    let line_start = Lsp_util.line_start_byte content ~line:e.line in
+    let range =
+      range_of_bytes
+        content
+        ~first_byte:line_start
+        ~last_byte:(line_start + String.length e.text)
+    in
+    Some
+      (CodeLens.create
+         ~range
+         ?command:
+           (Option.map target ~f:(fun (path, create) ->
+              Command.create
+                ~title:label
+                ~command:daily_note_command
+                ~arguments:[ `String path; `Bool create ]
+                ()))
+         ~data:(`String label)
+         ())
+;;
+
+(** Spec: {!page-"feature-command-block".surfaces}.  [None] outside a vault, so
+    a client learns nothing is coming rather than seeing an empty list. *)
+let code_lens (t : t) ~(rel_path : string) : CodeLens.t list option =
+  match t.vault with
+  | None -> None
+  | Some _ ->
+    let content = buffer_content t rel_path in
+    Command_block.entries content
+    |> List.filter_map ~f:(lens_of_entry t ~rel_path ~content)
+    |> Option.return
+;;
+
+(** The single action for the command-block line under the cursor, if that is
+    where the cursor is.  The keyboard route to what the lens offers. *)
+let command_block_actions (t : t) ~(rel_path : string) ~(line : int) : CodeAction.t list =
+  let content = buffer_content t rel_path in
+  match Command_block.entry_at content ~line with
+  | None -> []
+  | Some { command = None; _ } -> []
+  | Some { command = Some c; _ } ->
+    (match resolve_command t ~rel_path c with
+     | { target = None; _ } -> []
+     | { label; target = Some (path, create) } ->
+       [ CodeAction.create
+           ~title:label
+           ~kind:CodeActionKind.Refactor
+           ~isPreferred:true
+           ~command:
+             (Command.create
+                ~title:label
+                ~command:daily_note_command
+                ~arguments:[ `String path; `Bool create ]
+                ())
+           ()
+       ])
+;;
+
+(** The catalogue, offered inside a command block and nowhere else. *)
+let command_block_completions (t : t) ~(rel_path : string) ~(line : int)
+  : CompletionItem.t list option
+  =
+  let content = buffer_content t rel_path in
+  if not (Command_block.in_command_block content ~line)
+  then None
+  else
+    List.map Command_block.all_of_command ~f:(fun c ->
+      let name = Command_block.name_of_command c in
+      CompletionItem.create
+        ~label:name
+        ~kind:CompletionItemKind.Event
+        ~detail:(Command_block.doc_of_command c)
+          (* What it would do here, today — the same text the lens would show. *)
+        ~documentation:(`String (resolve_command t ~rel_path c).label)
+        ())
+    |> Option.return
+;;
+
 (** Handle [workspace/executeCommand].  [None] for an unknown command or
     unusable arguments — an editor is free to send either. *)
 let execute_command (t : t) ~(command : string) ~(arguments : Yojson.Safe.t list option)
@@ -558,7 +738,15 @@ let code_action
     | Some kinds -> List.mem kinds kind ~equal:Poly.equal
   in
   let daily =
-    if requested CodeActionKind.Refactor then daily_note_actions t ~rel_path else []
+    if requested CodeActionKind.Refactor
+    then (
+      (* On a command-block line the panel's own action is the answer, and the
+         whole daily-note menu would bury it.  See
+         {!page-"feature-command-block".surfaces}. *)
+      match command_block_actions t ~rel_path ~line:start_line with
+      | [] -> daily_note_actions t ~rel_path
+      | actions -> actions)
+    else []
   in
   let quick_fixes =
     match t.vault with
@@ -616,27 +804,33 @@ let completion (t : t) ~(rel_path : string) ~(line : int) ~(character : int)
   match t.vault with
   | None -> None
   | Some v ->
-    Feature.Completion.complete
-      ~index:v.index
-      ~rel_path
-      ~content:(buffer_content t rel_path)
-      ~line
-      ~character
-      ()
-    |> List.map ~f:(fun (i : Feature.Completion.item) ->
-      let kind =
-        match i.kind with
-        | Feature.Completion.File -> CompletionItemKind.File
-        | Feature.Completion.Reference -> CompletionItemKind.Reference
-      in
-      CompletionItem.create
-        ~label:i.label
-        ?detail:i.detail
-        ?filterText:i.filter_text
-        ?insertText:i.insert_text
-        ~kind
-        ())
-    |> Option.return
+    (* Inside a command block the note-name and fragment completions make no
+     sense: the content there is a command name.  See
+     {!page-"feature-command-block".surfaces}. *)
+    (match command_block_completions t ~rel_path ~line with
+     | Some items -> Some items
+     | None ->
+       Feature.Completion.complete
+         ~index:v.index
+         ~rel_path
+         ~content:(buffer_content t rel_path)
+         ~line
+         ~character
+         ()
+       |> List.map ~f:(fun (i : Feature.Completion.item) ->
+         let kind =
+           match i.kind with
+           | Feature.Completion.File -> CompletionItemKind.File
+           | Feature.Completion.Reference -> CompletionItemKind.Reference
+         in
+         CompletionItem.create
+           ~label:i.label
+           ?detail:i.detail
+           ?filterText:i.filter_text
+           ?insertText:i.insert_text
+           ~kind
+           ())
+       |> Option.return)
 ;;
 
 let inlay_hint (t : t) ~(rel_path : string) ~(start_line : int) ~(end_line : int)

--- a/pkg/oystermark/lsp/server.ml
+++ b/pkg/oystermark/lsp/server.ml
@@ -36,11 +36,37 @@ type t =
           the editor currently has open.  Diagnostics and the
           cursor-position features answer against this; the rest read from
           disk.  See {!page-"feature-document-sync"}. *)
+  ; mutable config : Lsp_config.t
+    (** Client-supplied settings, seen once at {!initialize}. *)
+  ; mutable daily_table : (Date.t * Daily_notes.Table.t) option
+    (** Memoized recognition table with the date it was built for; a server
+          left running overnight rebuilds it.  See
+          {!page-"feature-daily-notes".recognition}. *)
+  ; now : unit -> Date.t
+    (** The clock, as a dependency: daily-note answers depend on today's date,
+          and a test that cannot fix "today" would change meaning overnight. *)
   }
 
 let build_vault = Oystermark.Vault.of_root_path ~skip_expand:true
-let create () : t = { vault = None; open_docs = String.Table.create () }
-let initialize (t : t) ~(root : string) : unit = t.vault <- Some (build_vault root)
+
+(** Today in the machine's own timezone — the real clock, used unless a caller
+    substitutes one. *)
+let system_today () : Date.t = Date.today ~zone:(Lazy.force Time_float_unix.Zone.local)
+
+let create ?(now : unit -> Date.t = system_today) () : t =
+  { vault = None
+  ; open_docs = String.Table.create ()
+  ; config = Lsp_config.default
+  ; daily_table = None
+  ; now
+  }
+;;
+
+let initialize (t : t) ~(root : string) ?(init_options : Yojson.Safe.t option) () : unit =
+  t.config <- Lsp_config.of_initialization_options init_options;
+  t.daily_table <- None;
+  t.vault <- Some (build_vault root)
+;;
 
 let rebuild_vault (t : t) : unit =
   match t.vault with
@@ -357,6 +383,142 @@ let document_symbol (t : t) ~(rel_path : string) : DocumentSymbol.t list option 
     |> Option.return
 ;;
 
+(* Daily notes
+   ============
+
+   See {!page-"feature-daily-notes"}. *)
+
+(** The command a daily-note code action carries.  A code action cannot focus
+    an editor by itself, so the action defers to this command, which the client
+    sends back as [workspace/executeCommand]. *)
+let daily_note_command = "oystermark.dailyNote.open"
+
+(** What {!execute_command} decided should happen.  Returning an intent rather
+    than performing it keeps the protocol effects — [workspace/applyEdit] and
+    [window/showDocument] — in the adapter, and this decision testable. *)
+type open_note =
+  { uri : DocumentUri.t
+  ; create : WorkspaceEdit.t option (** [None] when the note already exists. *)
+  }
+
+(** Whether a vault-relative path exists on disk.  Read from disk rather than
+    the index because a note created moments ago by this very command has not
+    been indexed yet. *)
+let file_exists (t : t) (rel_path : string) : bool =
+  match vault_root t with
+  | None -> false
+  | Some root -> Stdlib.Sys.file_exists (Filename.concat root rel_path)
+;;
+
+(** The recognition table for the configured settings, rebuilt when the day
+    turns over.  [Error] when the configured format is unsupported, which
+    disables the daily-note actions. *)
+let daily_table (t : t) : (Daily_notes.Table.t, string) Result.t =
+  match Lsp_config.daily_notes_settings t.config with
+  | Error _ as e -> e
+  | Ok settings ->
+    let today = t.now () in
+    (match t.daily_table with
+     | Some (built_for, table) when Date.equal built_for today -> Ok table
+     | _ ->
+       let table = Daily_notes.Table.create settings ~today in
+       t.daily_table <- Some (today, table);
+       Ok table)
+;;
+
+(** One daily-note code action: a title that says whether the note will be
+    created, and the command that opens it. *)
+let daily_note_action (t : t) ~(title : string) ~(path : string) : CodeAction.t =
+  let exists = file_exists t path in
+  CodeAction.create
+    ~title:(sprintf "%s %s" (if exists then "Open" else "Create") title)
+    ~kind:CodeActionKind.Refactor
+    ~command:
+      (Command.create
+         ~title
+         ~command:daily_note_command
+         ~arguments:[ `String path; `Bool (not exists) ]
+         ())
+    ()
+;;
+
+(** The daily-note actions available at [rel_path].
+
+    The calendar family is always offered and creates on demand; the existing
+    family is offered only from a file that is itself a daily note, and only
+    when there is somewhere to go.  See {!page-"feature-daily-notes"}. *)
+let daily_note_actions (t : t) ~(rel_path : string) : CodeAction.t list =
+  match daily_table t with
+  | Error _ -> []
+  | Ok table ->
+    let settings = table.Daily_notes.Table.settings in
+    let today = t.now () in
+    let calendar =
+      [ "today's daily note", today
+      ; "yesterday's daily note", Date.add_days today (-1)
+      ; "tomorrow's daily note", Date.add_days today 1
+      ]
+      |> List.map ~f:(fun (title, date) ->
+        daily_note_action t ~title ~path:(Daily_notes.path_of_date settings date))
+    in
+    let existing =
+      match Daily_notes.Table.date_of_path table rel_path with
+      | None -> []
+      | Some date ->
+        let exists p = file_exists t p in
+        let step title f =
+          match f table ~exists date with
+          | None -> []
+          | Some (_, path) ->
+            [ CodeAction.create
+                ~title
+                ~kind:CodeActionKind.Refactor
+                ~command:
+                  (Command.create
+                     ~title
+                     ~command:daily_note_command
+                     ~arguments:[ `String path; `Bool false ]
+                     ())
+                ()
+            ]
+        in
+        step "Open previous daily note" Daily_notes.Table.previous_existing
+        @ step "Open next daily note" Daily_notes.Table.next_existing
+    in
+    calendar @ existing
+;;
+
+(** Handle [workspace/executeCommand].  [None] for an unknown command or
+    unusable arguments — an editor is free to send either. *)
+let execute_command (t : t) ~(command : string) ~(arguments : Yojson.Safe.t list option)
+  : open_note option
+  =
+  match command, arguments with
+  | cmd, Some [ `String path; `Bool create ] when String.equal cmd daily_note_command ->
+    let uri = uri_of_rel_path t path in
+    let create =
+      if create && not (file_exists t path)
+      then
+        Some
+          (WorkspaceEdit.create
+             ~documentChanges:
+               [ `CreateFile
+                   (CreateFile.create
+                      ~uri
+                      ~options:
+                        (CreateFileOptions.create
+                           ~ignoreIfExists:true
+                           ~overwrite:false
+                           ())
+                      ())
+               ]
+             ())
+      else None
+    in
+    Some { uri; create }
+  | _ -> None
+;;
+
 let code_action
       (t : t)
       ?(only : CodeActionKind.t list option)
@@ -368,56 +530,62 @@ let code_action
       ()
   : CodeAction.t list
   =
-  let quick_fixes_requested =
+  let requested (kind : CodeActionKind.t) =
     match only with
     | None -> true
-    | Some kinds -> List.mem kinds CodeActionKind.QuickFix ~equal:Poly.equal
+    | Some kinds -> List.mem kinds kind ~equal:Poly.equal
   in
-  match t.vault with
-  | _ when not quick_fixes_requested -> []
-  | None -> []
-  | Some v ->
-    let content = disk_content t rel_path in
-    (match
-       Feature.Create_unresolved_note.action_at_range
-         ~index:v.index
-         ~rel_path
-         ~content
-         ~first_byte:
-           (byte_of_position content ~line:start_line ~character:start_character)
-         ~last_byte:(byte_of_position content ~line:end_line ~character:end_character)
-     with
-     | None -> []
-     | Some action ->
-       let target_uri = uri_of_rel_path t action.rel_path in
-       let create =
-         `CreateFile
-           (CreateFile.create
-              ~uri:target_uri
-              ~options:
-                (CreateFileOptions.create ~ignoreIfExists:false ~overwrite:false ())
-              ())
-       in
-       let zero = Position.create ~line:0 ~character:0 in
-       let initialize =
-         `TextDocumentEdit
-           (TextDocumentEdit.create
-              ~textDocument:
-                (OptionalVersionedTextDocumentIdentifier.create ~uri:target_uri ())
-              ~edits:
-                [ `TextEdit
-                    (TextEdit.create
-                       ~range:(Range.create ~start:zero ~end_:zero)
-                       ~newText:("# " ^ action.title ^ "\n"))
-                ])
-       in
-       [ CodeAction.create
-           ~title:(sprintf "Create note \"%s\"" action.rel_path)
-           ~kind:CodeActionKind.QuickFix
-           ~isPreferred:true
-           ~edit:(WorkspaceEdit.create ~documentChanges:[ create; initialize ] ())
-           ()
-       ])
+  let daily =
+    if requested CodeActionKind.Refactor then daily_note_actions t ~rel_path else []
+  in
+  let quick_fixes =
+    match t.vault with
+    | _ when not (requested CodeActionKind.QuickFix) -> []
+    | None -> []
+    | Some v ->
+      let content = disk_content t rel_path in
+      (match
+         Feature.Create_unresolved_note.action_at_range
+           ~index:v.index
+           ~rel_path
+           ~content
+           ~first_byte:
+             (byte_of_position content ~line:start_line ~character:start_character)
+           ~last_byte:(byte_of_position content ~line:end_line ~character:end_character)
+       with
+       | None -> []
+       | Some action ->
+         let target_uri = uri_of_rel_path t action.rel_path in
+         let create =
+           `CreateFile
+             (CreateFile.create
+                ~uri:target_uri
+                ~options:
+                  (CreateFileOptions.create ~ignoreIfExists:false ~overwrite:false ())
+                ())
+         in
+         let zero = Position.create ~line:0 ~character:0 in
+         let initialize =
+           `TextDocumentEdit
+             (TextDocumentEdit.create
+                ~textDocument:
+                  (OptionalVersionedTextDocumentIdentifier.create ~uri:target_uri ())
+                ~edits:
+                  [ `TextEdit
+                      (TextEdit.create
+                         ~range:(Range.create ~start:zero ~end_:zero)
+                         ~newText:("# " ^ action.title ^ "\n"))
+                  ])
+         in
+         [ CodeAction.create
+             ~title:(sprintf "Create note \"%s\"" action.rel_path)
+             ~kind:CodeActionKind.QuickFix
+             ~isPreferred:true
+             ~edit:(WorkspaceEdit.create ~documentChanges:[ create; initialize ] ())
+             ()
+         ])
+  in
+  quick_fixes @ daily
 ;;
 
 let completion (t : t) ~(rel_path : string) ~(line : int) ~(character : int)

--- a/pkg/oystermark/lsp/server.mli
+++ b/pkg/oystermark/lsp/server.mli
@@ -71,6 +71,19 @@ val execute_command
 
 val uri_of_rel_path : t -> string -> DocumentUri.t
 
+(** {1 Command blocks}
+
+    See {!page-"feature-command-block"}.  A fenced [oysterlsp] block lifts the
+    commands above onto lines, where a lens can render them; the other surfaces
+    it adds — one code action on the cursor's line, completion of the command
+    names, a diagnostic on an unknown one — are folded into {!code_action},
+    {!completion} and the diagnostics the sync handlers return. *)
+
+(** Spec: {!page-"feature-command-block".surfaces}.  One lens per recognized
+    line; a line whose command cannot run right now keeps its lens, without a
+    command attached, so that {i why} stays visible. *)
+val code_lens : t -> rel_path:string -> CodeLens.t list option
+
 (** {1 Document synchronization}
 
     See {!page-"feature-document-sync"} for the full state machine.  Each

--- a/pkg/oystermark/lsp/server.mli
+++ b/pkg/oystermark/lsp/server.mli
@@ -27,7 +27,7 @@ val create : ?now:(unit -> Core.Date.t) -> unit -> t
 (** Build the vault from [root] and adopt the client's settings.  Called from
     [initialize] with its [rootUri] and [initializationOptions]; the options are
     taken raw so that parsing — and its tolerance for malformed input — lives in
-    {!Lsp_config}. *)
+    {!Lsp_lib.Config}. *)
 val initialize : t -> root:string -> ?init_options:Yojson.Safe.t -> unit -> unit
 
 (** The vault root, or [None] before {!initialize}. *)
@@ -45,6 +45,13 @@ val rel_path_of_uri : t -> DocumentUri.t -> string
 
 (** The command name advertised in [executeCommandProvider]. *)
 val daily_note_command : string
+
+(** [daily_notes_error t] is why the configured format was rejected — and hence
+    why no daily-note action is offered — or [None] when the settings are
+    usable.  Meaningful only after {!initialize}.  The adapter reports it once,
+    since a silent rejection is indistinguishable from an absent feature.
+    See {!page-"feature-daily-notes".format}. *)
+val daily_notes_error : t -> string option
 
 (** What running {!daily_note_command} decided: the note to focus, and the edit
     that creates it first when it does not exist. *)

--- a/pkg/oystermark/lsp/server.mli
+++ b/pkg/oystermark/lsp/server.mli
@@ -19,11 +19,16 @@ open Linol_lsp.Lsp.Types
 
 type t
 
-val create : unit -> t
+(** [create ?now ()] makes a server whose daily-note answers are dated by
+    [now], defaulting to the system clock.  Substituting it is what lets a test
+    of {!page-"feature-daily-notes"} mean the same thing tomorrow. *)
+val create : ?now:(unit -> Core.Date.t) -> unit -> t
 
-(** Build the vault from [root].  Called from [initialize] with the client's
-    [rootUri]. *)
-val initialize : t -> root:string -> unit
+(** Build the vault from [root] and adopt the client's settings.  Called from
+    [initialize] with its [rootUri] and [initializationOptions]; the options are
+    taken raw so that parsing — and its tolerance for malformed input — lives in
+    {!Lsp_config}. *)
+val initialize : t -> root:string -> ?init_options:Yojson.Safe.t -> unit -> unit
 
 (** The vault root, or [None] before {!initialize}. *)
 val vault_root : t -> string option
@@ -31,6 +36,30 @@ val vault_root : t -> string option
 (** Strip the vault root from [uri]'s path.  Falls back to the absolute path
     for files outside the vault (and before {!initialize}). *)
 val rel_path_of_uri : t -> DocumentUri.t -> string
+
+(** {1 Daily notes}
+
+    See {!page-"feature-daily-notes"}.  The code actions carry
+    {!daily_note_command}; running it yields an {!open_note} describing what the
+    adapter should ask the client to do. *)
+
+(** The command name advertised in [executeCommandProvider]. *)
+val daily_note_command : string
+
+(** What running {!daily_note_command} decided: the note to focus, and the edit
+    that creates it first when it does not exist. *)
+type open_note =
+  { uri : DocumentUri.t
+  ; create : WorkspaceEdit.t option
+  }
+
+(** Handle [workspace/executeCommand].  [None] for an unknown command or
+    unusable arguments. *)
+val execute_command
+  :  t
+  -> command:string
+  -> arguments:Yojson.Safe.t list option
+  -> open_note option
 
 val uri_of_rel_path : t -> string -> DocumentUri.t
 

--- a/pkg/oystermark/lsp/server.mli
+++ b/pkg/oystermark/lsp/server.mli
@@ -24,11 +24,19 @@ type t
     of {!page-"feature-daily-notes"} mean the same thing tomorrow. *)
 val create : ?now:(unit -> Core.Date.t) -> unit -> t
 
-(** Build the vault from [root] and adopt the client's settings.  Called from
-    [initialize] with its [rootUri] and [initializationOptions]; the options are
-    taken raw so that parsing — and its tolerance for malformed input — lives in
-    {!Lsp_lib.Config}. *)
+(** Build the vault from [root] and adopt the configuration: the client's
+    [initializationOptions], overridden by [oysterlsp.json] at the root.  The
+    options are taken raw so that parsing — and its tolerance for malformed
+    input — lives in {!Lsp_lib.Config}.  See {!page-"feature-configuration"}. *)
 val initialize : t -> root:string -> ?init_options:Yojson.Safe.t -> unit -> unit
+
+(** [config_warnings t] is everything the configuration sources asked for and
+    could not have: bad values, unknown keys, an unreadable [oysterlsp.json], a
+    rejected daily-note format.  Empty when the configuration is clean.
+    Computed by {!initialize}; the adapter reports each one, since a setting
+    ignored in silence is indistinguishable from one that does not exist.
+    See {!page-"feature-configuration".tolerance}. *)
+val config_warnings : t -> string list
 
 (** The vault root, or [None] before {!initialize}. *)
 val vault_root : t -> string option
@@ -45,13 +53,6 @@ val rel_path_of_uri : t -> DocumentUri.t -> string
 
 (** The command name advertised in [executeCommandProvider]. *)
 val daily_note_command : string
-
-(** [daily_notes_error t] is why the configured format was rejected — and hence
-    why no daily-note action is offered — or [None] when the settings are
-    usable.  Meaningful only after {!initialize}.  The adapter reports it once,
-    since a silent rejection is indistinguishable from an absent feature.
-    See {!page-"feature-daily-notes".format}. *)
-val daily_notes_error : t -> string option
 
 (** What running {!daily_note_command} decided: the note to focus, and the edit
     that creates it first when it does not exist. *)

--- a/pkg/oystermark/lsp/server.mli
+++ b/pkg/oystermark/lsp/server.mli
@@ -75,9 +75,10 @@ val uri_of_rel_path : t -> string -> DocumentUri.t
 
     See {!page-"feature-command-block"}.  A fenced [oysterlsp] block lifts the
     commands above onto lines, where a lens can render them; the other surfaces
-    it adds — one code action on the cursor's line, completion of the command
-    names, a diagnostic on an unknown one — are folded into {!code_action},
-    {!completion} and the diagnostics the sync handlers return. *)
+    it adds — one code action on the cursor's line, an action that seeds a note
+    with a block of its own, completion of the command names, a diagnostic on
+    an unknown one — are folded into {!code_action}, {!completion} and the
+    diagnostics the sync handlers return. *)
 
 (** Spec: {!page-"feature-command-block".surfaces}.  One lens per recognized
     line; a line whose command cannot run right now keeps its lens, without a

--- a/pkg/oystermark/tests/lsp/dune
+++ b/pkg/oystermark/tests/lsp/dune
@@ -4,6 +4,9 @@
  (libraries core core_unix linol.lsp lsp_lib trace_collect)
  (inline_tests
   (deps
-   (source_tree data)))
+   (source_tree data)
+   ;; The published schema is checked against the parser's own key inventory;
+   ;; see test_config_schema.ml.
+   %{project_root}/pkg/oystermark/lsp/oysterlsp.schema.json))
  (preprocess
   (pps ppx_expect ppx_jane)))

--- a/pkg/oystermark/tests/lsp/lsp_helper.ml
+++ b/pkg/oystermark/tests/lsp/lsp_helper.ml
@@ -17,10 +17,19 @@ module Server = Lsp_lib.Server
 (* Session
    ======== *)
 
-(** Create a server and point it at [vault_root], as [initialize] would. *)
-let start_server ~(vault_root : string) : Server.t =
-  let server = Server.create () in
-  Server.initialize server ~root:vault_root;
+(** Create a server and point it at [vault_root], as [initialize] would.
+    [init_options] stands in for the client's [initializationOptions], and
+    [today] fixes the clock so daily-note expectations do not drift.  See
+    {!page-"feature-daily-notes"}. *)
+let start_server
+      ?(init_options : Yojson.Safe.t option)
+      ?(today : Date.t option)
+      ~(vault_root : string)
+      ()
+  : Server.t
+  =
+  let server = Server.create ?now:(Option.map today ~f:(fun d () -> d)) () in
+  Server.initialize server ~root:vault_root ?init_options ();
   server
 ;;
 
@@ -150,19 +159,21 @@ let document_change_kinds (edit : WorkspaceEdit.t) : string list =
     edits raise, since a client's behaviour on them is undefined. *)
 let apply_edits (content : string) (edits : Lsp_lib.Rename.edit list) : string =
   List.sort edits ~compare:(fun a b -> Int.descending a.first_byte b.first_byte)
-  |> List.fold ~init:(content, String.length content) ~f:(fun (acc, prev_start) e ->
-    if e.last_byte > prev_start
-    then
-      failwithf
-        "overlapping edits: [%d-%d] extends past the next edit's start %d"
-        e.first_byte
-        e.last_byte
-        prev_start
-        ();
-    ( String.sub acc ~pos:0 ~len:e.first_byte
-      ^ e.new_text
-      ^ String.subo acc ~pos:e.last_byte
-    , e.first_byte ))
+  |> List.fold
+       ~init:(content, String.length content)
+       ~f:(fun (acc, prev_start) e ->
+         if e.last_byte > prev_start
+         then
+           failwithf
+             "overlapping edits: [%d-%d] extends past the next edit's start %d"
+             e.first_byte
+             e.last_byte
+             prev_start
+             ();
+         ( String.sub acc ~pos:0 ~len:e.first_byte
+           ^ e.new_text
+           ^ String.subo acc ~pos:e.last_byte
+         , e.first_byte ))
   |> fst
 ;;
 

--- a/pkg/oystermark/tests/lsp/test_command_block.ml
+++ b/pkg/oystermark/tests/lsp/test_command_block.ml
@@ -179,6 +179,7 @@ let%expect_test "the usual actions elsewhere in the note" =
     Create yesterday's daily note
     Create tomorrow's daily note
     Open previous daily note
+    Insert link to today's daily note
     |}]
 ;;
 
@@ -191,6 +192,7 @@ let%expect_test "no action for an inapplicable command" =
     Open today's daily note
     Create yesterday's daily note
     Create tomorrow's daily note
+    Insert link to today's daily note
     |}]
 ;;
 
@@ -215,8 +217,7 @@ let insert_line (edit : WorkspaceEdit.t) : int =
 ;;
 
 (** The insert action offered at [line] of [rel_path], with where it would
-    write and what.  Actions carrying no edit — the daily-note menu — are
-    dropped, since this is about the one that writes a block. *)
+    write and what. *)
 let show_insert ?(files = files) ?(line = 0) rel_path =
   with_tmp_vault ~files (fun vault_root ->
     let s = start ~vault_root in
@@ -228,6 +229,10 @@ let show_insert ?(files = files) ?(line = 0) rel_path =
       ~end_line:line
       ~end_character:0
       ()
+    (* Other actions carry edits too — the daily-note link, for one — so
+       select this one by name rather than by having an edit at all. *)
+    |> List.filter ~f:(fun (a : CodeAction.t) ->
+      String.is_substring a.title ~substring:"command block")
     |> List.iter ~f:(fun (a : CodeAction.t) ->
       Option.iter a.edit ~f:(fun edit ->
         printf "%s, at line %d\n" a.title (insert_line edit);

--- a/pkg/oystermark/tests/lsp/test_command_block.ml
+++ b/pkg/oystermark/tests/lsp/test_command_block.ml
@@ -194,6 +194,145 @@ let%expect_test "no action for an inapplicable command" =
     |}]
 ;;
 
+(** {1 Creating a block}
+
+    See {!page-"feature-command-block".insert}: which notes are offered a
+    panel, and which lines it comes with. *)
+
+(** The line a workspace edit's first text edit starts at, [-1] if it has
+    none.  The block goes in at the cursor, and an edit with the right text at
+    the wrong place is still wrong. *)
+let insert_line (edit : WorkspaceEdit.t) : int =
+  Option.value edit.documentChanges ~default:[]
+  |> List.find_map ~f:(function
+    | `TextDocumentEdit (e : TextDocumentEdit.t) ->
+      List.hd e.edits
+      |> Option.map ~f:(function
+        | `TextEdit (t : TextEdit.t) -> t.range.start.line
+        | `AnnotatedTextEdit (t : AnnotatedTextEdit.t) -> t.range.start.line)
+    | `CreateFile _ | `RenameFile _ | `DeleteFile _ -> None)
+  |> Option.value ~default:(-1)
+;;
+
+(** The insert action offered at [line] of [rel_path], with where it would
+    write and what.  Actions carrying no edit — the daily-note menu — are
+    dropped, since this is about the one that writes a block. *)
+let show_insert ?(files = files) ?(line = 0) rel_path =
+  with_tmp_vault ~files (fun vault_root ->
+    let s = start ~vault_root in
+    Server.code_action
+      s
+      ~rel_path
+      ~start_line:line
+      ~start_character:0
+      ~end_line:line
+      ~end_character:0
+      ()
+    |> List.iter ~f:(fun (a : CodeAction.t) ->
+      Option.iter a.edit ~f:(fun edit ->
+        printf "%s, at line %d\n" a.title (insert_line edit);
+        List.iter (inserted_texts edit) ~f:print_string)))
+;;
+
+(* An ordinary note gets the calendar three; previous and next would be dead
+   the moment they were written. *)
+let%expect_test "an ordinary note is offered the calendar commands" =
+  show_insert ~files:[ "plain.md", "# Nothing here\n" ] "plain.md";
+  [%expect
+    {|
+    Insert oysterlsp command block, at line 0
+    ```oysterlsp
+    daily/today
+    daily/yesterday
+    daily/tomorrow
+    ```
+    |}]
+;;
+
+(* The panel goes in where the cursor is, not at the top of the note. *)
+let%expect_test "the block is written at the cursor's line" =
+  show_insert ~files:[ "plain.md", "# Nothing here\n\nprose.\n" ] ~line:2 "plain.md";
+  [%expect
+    {|
+    Insert oysterlsp command block, at line 2
+    ```oysterlsp
+    daily/today
+    daily/yesterday
+    daily/tomorrow
+    ```
+    |}]
+;;
+
+(* A daily note in the middle of the journal can use all five. *)
+let%expect_test "a daily note with neighbours is offered all five" =
+  let files =
+    List.map files ~f:(fun (path, content) ->
+      if String.equal path "journal/2026-07-10.md"
+      then path, "# Middle\n"
+      else path, content)
+  in
+  show_insert ~files "journal/2026-07-10.md";
+  [%expect
+    {|
+    Insert oysterlsp command block, at line 0
+    ```oysterlsp
+    daily/today
+    daily/yesterday
+    daily/tomorrow
+    daily/prev
+    daily/next
+    ```
+    |}]
+;;
+
+(* The earliest daily note has nothing behind it, so [daily/prev] is left out
+   of the block rather than written and immediately reported dead. *)
+let%expect_test "the earliest daily note gets no daily/prev" =
+  show_insert "journal/2026-07-03.md";
+  [%expect
+    {|
+    Insert oysterlsp command block, at line 0
+    ```oysterlsp
+    daily/today
+    daily/yesterday
+    daily/tomorrow
+    daily/next
+    ```
+    |}]
+;;
+
+(* Once a note has a panel the action stops: adding a line to one is typing,
+   which completion already helps with. *)
+let%expect_test "a note that already has a block is offered nothing" =
+  show_insert "idea.md";
+  [%expect {| |}]
+;;
+
+(* With daily notes disabled nothing resolves, and a block of dead lines is
+   not worth writing. *)
+let%expect_test "no commands, no block" =
+  with_tmp_vault
+    ~files:[ "plain.md", "# Nothing here\n" ]
+    (fun vault_root ->
+       let s =
+         start_server
+           ~init_options:(`Assoc [ "dailyNotes", `Assoc [ "format", `String "YYYY-ww" ] ])
+           ~today
+           ~vault_root
+           ()
+       in
+       Server.code_action
+         s
+         ~rel_path:"plain.md"
+         ~start_line:0
+         ~start_character:0
+         ~end_line:0
+         ~end_character:0
+         ()
+       |> List.iter ~f:(fun (a : CodeAction.t) -> printf "%s\n" a.title));
+  [%expect {| |}]
+;;
+
 (** {1 Completion and diagnostics} *)
 
 let%expect_test "completion inside the block offers the catalogue" =

--- a/pkg/oystermark/tests/lsp/test_command_block.ml
+++ b/pkg/oystermark/tests/lsp/test_command_block.ml
@@ -1,0 +1,246 @@
+(** Spec: {!page-"feature-command-block"}.
+    Impl: {!Lsp_lib.Command_block} (finding the lines) and {!Lsp_lib.Server}
+    (the four surfaces built on them).
+
+    {!Lsp_lib.Command_block}'s own tests cover recognition; these check what a
+    server answers with, which is where the block meets the vault, the clock
+    and the daily-note settings. *)
+
+open Core
+open Linol_lsp.Lsp.Types
+open Lsp_helper
+
+(* Fixed so the expectations mean the same thing tomorrow. *)
+let today = Date.create_exn ~y:2026 ~m:Month.Jul ~d:26
+
+let panel =
+  {|```oysterlsp
+daily/today
+daily/yesterday
+daily/prev
+daily/next
+```
+|}
+;;
+
+let files =
+  [ "journal/2026-07-03.md", "# Early\n"
+  ; "journal/2026-07-10.md", "# Middle\n"
+  ; "journal/2026-07-26.md", "# Today\n\n" ^ panel
+  ; "idea.md", "# An idea\n\n" ^ panel
+  ]
+;;
+
+let options : Yojson.Safe.t =
+  `Assoc
+    [ "dailyNotes", `Assoc [ "format", `String "YYYY-MM-DD"; "folder", `String "journal" ]
+    ]
+;;
+
+let start ~vault_root = start_server ~init_options:options ~today ~vault_root ()
+
+(** Every lens in [rel_path]: its line, its title, and the command it carries
+    (or nothing, when the command cannot run here). *)
+let show_lenses ?(files = files) rel_path =
+  with_tmp_vault ~files (fun vault_root ->
+    let s = start ~vault_root in
+    match Server.code_lens s ~rel_path with
+    | None -> print_endline "no vault"
+    | Some lenses ->
+      List.iter lenses ~f:(fun (l : CodeLens.t) ->
+        printf
+          "%d: %s\n"
+          l.range.start.line
+          (match l.command with
+           | Some c ->
+             sprintf
+               "%s -> %s"
+               c.title
+               (String.concat
+                  ~sep:" "
+                  (List.map
+                     (Option.value c.arguments ~default:[])
+                     ~f:Yojson.Safe.to_string))
+           | None -> "(nothing to run)")))
+;;
+
+(** {1 Lenses}
+
+    See {!page-"feature-command-block".surfaces}. *)
+
+(* From a daily note, every line of the panel resolves: the calendar three
+   against the clock, previous/next against *this* note's date. *)
+let%expect_test "a panel inside a daily note" =
+  show_lenses "journal/2026-07-26.md";
+  [%expect
+    {|
+    3: Open today's daily note -> "journal/2026-07-26.md" false
+    4: Create yesterday's daily note -> "journal/2026-07-25.md" true
+    5: Open previous daily note (journal/2026-07-10.md) -> "journal/2026-07-10.md" false
+    6: (nothing to run)
+    |}]
+;;
+
+(* The same block in an ordinary note: the calendar commands are unchanged,
+   but previous/next have no date to move from.  They keep their lens and say
+   so — a lens that vanished would look like a server that failed. *)
+let%expect_test "the same panel in an ordinary note" =
+  show_lenses "idea.md";
+  [%expect
+    {|
+    3: Open today's daily note -> "journal/2026-07-26.md" false
+    4: Create yesterday's daily note -> "journal/2026-07-25.md" true
+    5: (nothing to run)
+    6: (nothing to run)
+    |}]
+;;
+
+(* The point of putting the panel in a note: the identical block means
+   different things in two of them. *)
+let%expect_test "previous and next follow the host note" =
+  (* Replace, rather than prepend: {!with_tmp_vault} writes in order, so a
+     second entry for the same path would overwrite the panel. *)
+  let files =
+    List.map files ~f:(fun (path, content) ->
+      if String.equal path "journal/2026-07-10.md"
+      then path, "# Middle\n\n" ^ panel
+      else path, content)
+  in
+  show_lenses ~files "journal/2026-07-10.md";
+  [%expect
+    {|
+    3: Open today's daily note -> "journal/2026-07-26.md" false
+    4: Create yesterday's daily note -> "journal/2026-07-25.md" true
+    5: Open previous daily note (journal/2026-07-03.md) -> "journal/2026-07-03.md" false
+    6: Open next daily note (journal/2026-07-26.md) -> "journal/2026-07-26.md" false
+    |}]
+;;
+
+let%expect_test "a note with no block has no lenses" =
+  show_lenses ~files:[ "plain.md", "# Nothing here\n" ] "plain.md";
+  [%expect {| |}]
+;;
+
+(* An unsupported daily-note format disables the commands; the lines still
+   report why rather than going quiet. *)
+let%expect_test "daily notes disabled" =
+  with_tmp_vault ~files (fun vault_root ->
+    let s =
+      start_server
+        ~init_options:(`Assoc [ "dailyNotes", `Assoc [ "format", `String "YYYY-ww" ] ])
+        ~today
+        ~vault_root
+        ()
+    in
+    Option.iter (Server.code_lens s ~rel_path:"idea.md") ~f:(fun lenses ->
+      List.iter lenses ~f:(fun (l : CodeLens.t) ->
+        printf "%d: %b\n" l.range.start.line (Option.is_some l.command))));
+  [%expect
+    {|
+    3: false
+    4: false
+    5: false
+    6: false
+    |}]
+;;
+
+(** {1 Code action}
+
+    The keyboard route to the same command, for clients that render no
+    lenses. *)
+
+let show_action ?(rel_path = "journal/2026-07-26.md") line =
+  with_tmp_vault ~files (fun vault_root ->
+    let s = start ~vault_root in
+    Server.code_action
+      s
+      ~rel_path
+      ~start_line:line
+      ~start_character:0
+      ~end_line:line
+      ~end_character:0
+      ()
+    |> List.iter ~f:(fun (a : CodeAction.t) -> printf "%s\n" a.title))
+;;
+
+(* On a panel line, exactly one action: the line's own.  The daily-note menu
+   would otherwise bury it under five. *)
+let%expect_test "one action on a command line" =
+  show_action 4;
+  [%expect {| Create yesterday's daily note |}]
+;;
+
+(* Off the panel, the ordinary menu is unchanged. *)
+let%expect_test "the usual actions elsewhere in the note" =
+  show_action 0;
+  [%expect
+    {|
+    Open today's daily note
+    Create yesterday's daily note
+    Create tomorrow's daily note
+    Open previous daily note
+    |}]
+;;
+
+(* A line whose command cannot run offers no action — there is nothing to
+   apply.  The lens still explains it. *)
+let%expect_test "no action for an inapplicable command" =
+  show_action ~rel_path:"idea.md" 5;
+  [%expect
+    {|
+    Open today's daily note
+    Create yesterday's daily note
+    Create tomorrow's daily note
+    |}]
+;;
+
+(** {1 Completion and diagnostics} *)
+
+let%expect_test "completion inside the block offers the catalogue" =
+  with_tmp_vault ~files (fun vault_root ->
+    let s = start ~vault_root in
+    match Server.completion s ~rel_path:"idea.md" ~line:4 ~character:0 with
+    | None -> print_endline "none"
+    | Some items ->
+      List.iter items ~f:(fun (i : CompletionItem.t) ->
+        printf "%-16s %s\n" i.label (Option.value i.detail ~default:"")));
+  [%expect
+    {|
+    daily/today      Open today's daily note, creating it when missing
+    daily/yesterday  Open yesterday's daily note, creating it when missing
+    daily/tomorrow   Open tomorrow's daily note, creating it when missing
+    daily/prev       Open the previous existing daily note, relative to this note
+    daily/next       Open the next existing daily note, relative to this note
+    |}]
+;;
+
+(* A misspelling is inert, and inert looks exactly like unimplemented — so it
+   is diagnosed. *)
+let%expect_test "an unknown command name is diagnosed" =
+  let content =
+    {|# Note
+
+```oysterlsp
+daily/today
+daily/yesterdya
+```
+|}
+  in
+  with_tmp_vault
+    ~files:[ "typo.md", content ]
+    (fun vault_root ->
+       let s = start ~vault_root in
+       Server.did_open s ~rel_path:"typo.md" ~content
+       |> List.iter ~f:(fun (d : Diagnostic.t) ->
+         printf
+           "%d:%d %s\n"
+           d.range.start.line
+           d.range.start.character
+           (match d.message with
+            | `String m -> m
+            | _ -> "")));
+  [%expect
+    {|
+    4:0 unknown oysterlsp command "daily/yesterdya"; expected one of daily/today, daily/yesterday, daily/tomorrow, daily/prev, daily/next
+    |}]
+;;

--- a/pkg/oystermark/tests/lsp/test_completion.ml
+++ b/pkg/oystermark/tests/lsp/test_completion.ml
@@ -15,7 +15,7 @@ let vault_root =
    heading slug and the attribute id — are offered.
    See {!page-"feature-attribute-anchors"}. *)
 let%expect_test "server: fragment completion offers heading and attribute id" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"complete-src.md";
   Server.completion s ~rel_path:"complete-src.md" ~line:2 ~character:20
   |> completion_items

--- a/pkg/oystermark/tests/lsp/test_config_schema.ml
+++ b/pkg/oystermark/tests/lsp/test_config_schema.ml
@@ -1,0 +1,133 @@
+(** Spec: {!page-"feature-configuration".schema-file}.
+    Impl: [lsp/oysterlsp.schema.json] and {!Lsp_lib.Config}.
+
+    The published schema is a second statement of what the parser accepts, and
+    two statements drift. These tests make drift fail: the schema's keys and
+    {!Lsp_lib.Config.known_keys} must agree, and every key in that inventory
+    must be one the parser really knows — a name in a list proves nothing on
+    its own. *)
+
+open Core
+module Config = Lsp_lib.Config
+
+let schema_path = "../../lsp/oysterlsp.schema.json"
+let schema () : Yojson.Safe.t = Yojson.Safe.from_string (In_channel.read_all schema_path)
+
+(** Every dotted leaf key the schema declares, [$schema] aside: it is an
+    editor association rather than a setting, and {!Config.known_keys} does not
+    list it. *)
+let schema_keys () : string list =
+  let properties (j : Yojson.Safe.t) =
+    match j with
+    | `Assoc fields ->
+      (match List.Assoc.find fields "properties" ~equal:String.equal with
+       | Some (`Assoc props) -> props
+       | _ -> [])
+    | _ -> []
+  in
+  properties (schema ())
+  |> List.concat_map ~f:(fun (section, sub) ->
+    match properties sub with
+    | [] -> if String.equal section "$schema" then [] else [ section ]
+    | leaves -> List.map leaves ~f:(fun (leaf, _) -> section ^ "." ^ leaf))
+  |> List.sort ~compare:String.compare
+;;
+
+(* A key in the schema that the parser does not accept would be advertised
+   completion for a setting that does nothing; a key the parser accepts but
+   the schema omits would be flagged as invalid in the user's editor. Both
+   directions are failures, so compare the sets. *)
+let%expect_test "the schema and the parser accept the same keys" =
+  let inventory = List.sort Config.known_keys ~compare:String.compare in
+  let schema = schema_keys () in
+  let missing =
+    List.filter inventory ~f:(fun k -> not (List.mem schema k ~equal:String.equal))
+  in
+  let extra =
+    List.filter schema ~f:(fun k -> not (List.mem inventory k ~equal:String.equal))
+  in
+  printf "in the parser, not the schema: %s\n" (String.concat ~sep:", " missing);
+  printf "in the schema, not the parser: %s\n" (String.concat ~sep:", " extra);
+  [%expect
+    {|
+    in the parser, not the schema:
+    in the schema, not the parser:
+    |}]
+;;
+
+(* [known_keys] is hand-written beside a hand-written parser, so it could
+   name a key that no longer exists. Feeding each key a value of deliberately
+   wrong type distinguishes the two failures the parser reports: a key it
+   knows complains about the value, an unknown one complains about the key. *)
+let%expect_test "every inventoried key is one the parser knows" =
+  List.iter Config.known_keys ~f:(fun key ->
+    let json =
+      match String.split key ~on:'.' with
+      | [ section; leaf ] -> `Assoc [ section, `Assoc [ leaf, `List [] ] ]
+      | _ -> `Assoc [ key, `List [] ]
+    in
+    let _, warnings = Config.parse json in
+    let unknown =
+      List.exists warnings ~f:(fun w -> String.is_substring w ~substring:"unknown key")
+    in
+    if unknown then printf "%s: not known to the parser\n" key);
+  [%expect {| |}]
+;;
+
+(* The URL is written twice — as the schema's own [$id] and as the value
+   [--print-default-config] emits — and an emitted association pointing
+   somewhere the schema does not claim to be is a broken association. It must
+   also be a raw URL: a github.com/blob link serves HTML, which a JSON
+   language server cannot read. *)
+let%expect_test "the emitted association matches the schema's own $id" =
+  let id =
+    match schema () with
+    | `Assoc fields ->
+      (match List.Assoc.find fields "$id" ~equal:String.equal with
+       | Some (`String s) -> s
+       | _ -> "<none>")
+    | _ -> "<none>"
+  in
+  printf "same: %b\n" (String.equal id Config.schema_url);
+  printf
+    "raw host: %b\n"
+    (String.is_prefix id ~prefix:"https://raw.githubusercontent.com/");
+  [%expect
+    {|
+    same: true
+    raw host: true
+    |}]
+;;
+
+(* The association line the schema exists to be reached by must not itself be
+   reported as a stray setting. *)
+let%expect_test "$schema is accepted and is not a setting" =
+  let config, warnings =
+    Config.parse
+      (`Assoc
+          [ "$schema", `String "https://oystermark.dev/oysterlsp.schema.json"
+          ; "hover", `Assoc [ "maxChars", `Int 40 ]
+          ])
+  in
+  printf "warnings: %d\n" (List.length warnings);
+  printf "maxChars: %d\n" (Config.resolve config).hover_max_chars;
+  [%expect
+    {|
+    warnings: 0
+    maxChars: 40
+    |}]
+;;
+
+(* What [--print-default-config] hands over has to be a file this server
+   accepts: defaults in, defaults out, no warnings. *)
+let%expect_test "the emitted default config round-trips" =
+  let json = Config.to_json Config.default in
+  let parsed, warnings = Config.parse json in
+  printf "warnings: %s\n" (String.concat ~sep:"; " warnings);
+  printf "same as default: %b\n" (Config.equal (Config.resolve parsed) Config.default);
+  [%expect
+    {|
+    warnings:
+    same as default: true
+    |}]
+;;

--- a/pkg/oystermark/tests/lsp/test_configuration.ml
+++ b/pkg/oystermark/tests/lsp/test_configuration.ml
@@ -1,0 +1,164 @@
+(** Spec: {!page-"feature-configuration"}.
+    Impl: {!Lsp_lib.Config} (parsing and merging) and {!Lsp_lib.Server}
+    (adoption at [initialize], and the warnings the adapter reports).
+
+    {!Lsp_lib.Config}'s own tests cover the schema case by case; these run the
+    whole path — a file on disk, a client's [initializationOptions], and the
+    settings a running server ends up behaving by. *)
+
+open Core
+open Lsp_helper
+
+(* Fixed so daily-note expectations mean the same thing tomorrow. *)
+let today = Date.create_exn ~y:2026 ~m:Month.Jul ~d:26
+let files = [ "journal/2026-07-26.md", "# Today\n"; "idea.md", "# Not a daily note\n" ]
+
+(** Start a server against a vault that does or does not contain
+    [oysterlsp.json], and show what it decided plus anything it complained
+    about.  The daily-note path stands in for the resolved settings: it is the
+    one setting whose effect is visible without a request. *)
+let show ?(config_file : string option) ?(init_options : string option) () =
+  let files =
+    match config_file with
+    | None -> files
+    | Some contents -> ("oysterlsp.json", contents) :: files
+  in
+  with_tmp_vault ~files (fun vault_root ->
+    let init_options = Option.map init_options ~f:Yojson.Safe.from_string in
+    let s = start_server ?init_options ~today ~vault_root () in
+    Server.code_action
+      s
+      ~rel_path:"idea.md"
+      ~start_line:0
+      ~start_character:0
+      ~end_line:0
+      ~end_character:0
+      ()
+    |> List.iter ~f:(fun (a : Linol_lsp.Lsp.Types.CodeAction.t) ->
+      match a.command with
+      | Some { arguments = Some (`String path :: _); _ } -> printf "%s\n" path
+      | _ -> ());
+    List.iter (Server.config_warnings s) ~f:(printf "! %s\n"))
+;;
+
+(** {1 Sources} *)
+
+let%expect_test "no configuration at all: defaults, and nothing to say" =
+  show ();
+  [%expect
+    {|
+    2026-07-26.md
+    2026-07-25.md
+    2026-07-27.md
+    |}]
+;;
+
+let%expect_test "the file alone" =
+  show ~config_file:{|{"dailyNotes": {"folder": "journal"}}|} ();
+  [%expect
+    {|
+    journal/2026-07-26.md
+    journal/2026-07-25.md
+    journal/2026-07-27.md
+    |}]
+;;
+
+let%expect_test "initializationOptions alone" =
+  show ~init_options:{|{"dailyNotes": {"folder": "journal"}}|} ();
+  [%expect
+    {|
+    journal/2026-07-26.md
+    journal/2026-07-25.md
+    journal/2026-07-27.md
+    |}]
+;;
+
+(* The vault's own file describes the vault, so it wins — but only key by key:
+   the client's [format] survives a file that names only [folder]. *)
+let%expect_test "the file wins, field by field" =
+  (* The file names only [folder], and the client's [format] is deliberately
+     not the default — so a nested path proves the client's key survived while
+     the file's overrode the same key. *)
+  show
+    ~config_file:{|{"dailyNotes": {"folder": "journal"}}|}
+    ~init_options:
+      {|{"dailyNotes": {"folder": "elsewhere", "format": "YYYY/MM/YYYY-MM-DD"}}|}
+    ();
+  [%expect
+    {|
+    journal/2026/07/2026-07-26.md
+    journal/2026/07/2026-07-25.md
+    journal/2026/07/2026-07-27.md
+    |}]
+;;
+
+(** {1 Tolerance}
+
+    Nothing below prevents the server from starting, and nothing is ignored
+    quietly.  See {!page-"feature-configuration".tolerance}. *)
+
+let%expect_test "a broken file leaves the client's settings, and is reported" =
+  show
+    ~config_file:{|{"dailyNotes": {"folder":|}
+    ~init_options:{|{"dailyNotes": {"folder": "journal"}}|}
+    ();
+  [%expect
+    {|
+    journal/2026-07-26.md
+    journal/2026-07-25.md
+    journal/2026-07-27.md
+    ! oysterlsp.json: not valid JSON — Line 1, bytes 24-25: Unexpected end of input
+    |}]
+;;
+
+let%expect_test "unusable values and unknown keys are named, with their source" =
+  show
+    ~config_file:{|{"dailyNotes": {"folder": "journal"}, "hover": {"maxChars": -1}}|}
+    ~init_options:{|{"dailynotes": {"folder": "typo"}}|}
+    ();
+  [%expect
+    {|
+    journal/2026-07-26.md
+    journal/2026-07-25.md
+    journal/2026-07-27.md
+    ! initializationOptions: unknown key "dailynotes"
+    ! oysterlsp.json: hover.maxChars: expected a positive integer, got -1
+    |}]
+;;
+
+(* A format that parses but names no single day disables the feature.  It is
+   validated after merging, so it joins the same warning list. *)
+let%expect_test "a rejected daily-note format" =
+  show ~config_file:{|{"dailyNotes": {"format": "YYYY-ww"}}|} ();
+  [%expect {| ! daily notes disabled: unsupported format token 'w' |}]
+;;
+
+(* The file is read from the vault root, so a server that never saw a root
+   never reads one. *)
+let%expect_test "config file in a subfolder is not read" =
+  with_tmp_vault
+    ~files:(("sub/oysterlsp.json", {|{"dailyNotes": {"folder": "journal"}}|}) :: files)
+    (fun vault_root ->
+       let s = start_server ~today ~vault_root () in
+       printf "%s\n" (Server.rel_path_of_uri s (Server.uri_of_rel_path s "x.md"));
+       List.iter (Server.config_warnings s) ~f:(printf "! %s\n");
+       Server.code_action
+         s
+         ~rel_path:"idea.md"
+         ~start_line:0
+         ~start_character:0
+         ~end_line:0
+         ~end_character:0
+         ()
+       |> List.iter ~f:(fun (a : Linol_lsp.Lsp.Types.CodeAction.t) ->
+         match a.command with
+         | Some { arguments = Some (`String path :: _); _ } -> printf "%s\n" path
+         | _ -> ()));
+  [%expect
+    {|
+    x.md
+    2026-07-26.md
+    2026-07-25.md
+    2026-07-27.md
+    |}]
+;;

--- a/pkg/oystermark/tests/lsp/test_create_unresolved_note.ml
+++ b/pkg/oystermark/tests/lsp/test_create_unresolved_note.ml
@@ -51,10 +51,13 @@ let%expect_test "fragments, embeds, images, and traversal have no action" =
 
 let%expect_test "server: quick fix creates and initializes the note" =
   let vault_root = Filename.concat (Core_unix.getcwd ()) "data" in
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
+  (* Ask for quick fixes only: the daily-note actions are [Refactor] and carry
+     a command rather than an edit.  See {!page-"feature-daily-notes"}. *)
   Server.code_action
     s
+    ~only:[ CodeActionKind.QuickFix ]
     ~rel_path:"note-b.md"
     ~start_line:10
     ~start_character:11

--- a/pkg/oystermark/tests/lsp/test_daily_notes.ml
+++ b/pkg/oystermark/tests/lsp/test_daily_notes.ml
@@ -57,6 +57,7 @@ let%expect_test "actions from a daily note: calendar plus previous/next" =
     Create yesterday's daily note    "journal/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026-07-27.md" true
     Open previous daily note         "journal/2026-07-10.md" false
+    Insert oysterlsp command block   no command
     |}]
 ;;
 
@@ -72,6 +73,7 @@ let%expect_test "previous and next from the middle of the range" =
     Create tomorrow's daily note     "journal/2026-07-27.md" true
     Open previous daily note         "journal/2026-07-03.md" false
     Open next daily note             "journal/2026-07-26.md" false
+    Insert oysterlsp command block   no command
     |}]
 ;;
 
@@ -84,6 +86,7 @@ let%expect_test "actions from an ordinary note" =
     Open today's daily note          "journal/2026-07-26.md" false
     Create yesterday's daily note    "journal/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026-07-27.md" true
+    Insert oysterlsp command block   no command
     |}]
 ;;
 
@@ -96,6 +99,7 @@ let%expect_test "nested format" =
     Create today's daily note        "journal/2026/07/2026-07-26.md" true
     Create yesterday's daily note    "journal/2026/07/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026/07/2026-07-27.md" true
+    Insert oysterlsp command block   no command
     |}]
 ;;
 

--- a/pkg/oystermark/tests/lsp/test_daily_notes.ml
+++ b/pkg/oystermark/tests/lsp/test_daily_notes.ml
@@ -1,0 +1,162 @@
+(** Spec: {!page-"feature-daily-notes"}.
+    Impl: {!Lsp_lib.Daily_notes} (pure layer) and {!Lsp_lib.Server} (actions and
+    the command).
+
+    The pure layer's own tests live beside it; these drive the server, where
+    settings, the clock, and the disk meet. *)
+
+open Core
+open Linol_lsp.Lsp.Types
+open Lsp_helper
+
+(* "Today" is fixed so these expectations mean the same thing tomorrow; the
+   fixture dates are chosen around it, with gaps to exercise previous/next. *)
+let today = Date.create_exn ~y:2026 ~m:Month.Jul ~d:26
+
+let files =
+  [ "journal/2026-07-03.md", "# Friday\n"
+  ; "journal/2026-07-10.md", "# Friday again\n"
+  ; "journal/2026-07-26.md", "# Today\n"
+  ; "idea.md", "# Not a daily note\n"
+  ]
+;;
+
+let options ?(folder = "journal") (format : string) : Yojson.Safe.t =
+  `Assoc [ "dailyNotes", `Assoc [ "format", `String format; "folder", `String folder ] ]
+;;
+
+(** Every code action offered at [rel_path], as [title -> command arguments]. *)
+let show_actions ?(init_options = options "YYYY-MM-DD") ~(vault_root : string) rel_path =
+  let s = start_server ~init_options ~today ~vault_root () in
+  did_open s ~rel_path;
+  Server.code_action
+    s
+    ~rel_path
+    ~start_line:0
+    ~start_character:0
+    ~end_line:0
+    ~end_character:0
+    ()
+  |> List.iter ~f:(fun (a : CodeAction.t) ->
+    let args =
+      match a.command with
+      | None -> "no command"
+      | Some c ->
+        List.map (Option.value c.arguments ~default:[]) ~f:Yojson.Safe.to_string
+        |> String.concat ~sep:" "
+    in
+    printf "%-32s %s\n" a.title args)
+;;
+
+let%expect_test "actions from a daily note: calendar plus previous/next" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_actions ~vault_root "journal/2026-07-26.md");
+  [%expect
+    {|
+    Open today's daily note          "journal/2026-07-26.md" false
+    Create yesterday's daily note    "journal/2026-07-25.md" true
+    Create tomorrow's daily note     "journal/2026-07-27.md" true
+    Open previous daily note         "journal/2026-07-10.md" false
+    |}]
+;;
+
+(* Previous/next skip the gap between the 3rd and the 10th, and stop at the
+   ends of what exists — they never create. *)
+let%expect_test "previous and next from the middle of the range" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_actions ~vault_root "journal/2026-07-10.md");
+  [%expect
+    {|
+    Open today's daily note          "journal/2026-07-26.md" false
+    Create yesterday's daily note    "journal/2026-07-25.md" true
+    Create tomorrow's daily note     "journal/2026-07-27.md" true
+    Open previous daily note         "journal/2026-07-03.md" false
+    Open next daily note             "journal/2026-07-26.md" false
+    |}]
+;;
+
+(* Off a daily note the calendar family is still offered; the existing family
+   is not, because there is no current date to move from. *)
+let%expect_test "actions from an ordinary note" =
+  with_tmp_vault ~files (fun vault_root -> show_actions ~vault_root "idea.md");
+  [%expect
+    {|
+    Open today's daily note          "journal/2026-07-26.md" false
+    Create yesterday's daily note    "journal/2026-07-25.md" true
+    Create tomorrow's daily note     "journal/2026-07-27.md" true
+    |}]
+;;
+
+(* A format with [/] nests the note in folders; the paths follow. *)
+let%expect_test "nested format" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_actions ~init_options:(options "YYYY/MM/YYYY-MM-DD") ~vault_root "idea.md");
+  [%expect
+    {|
+    Create today's daily note        "journal/2026/07/2026-07-26.md" true
+    Create yesterday's daily note    "journal/2026/07/2026-07-25.md" true
+    Create tomorrow's daily note     "journal/2026/07/2026-07-27.md" true
+    |}]
+;;
+
+(* An unsupported format disables the feature rather than naming a wrong file.
+   The unrelated quick-fix actions are unaffected. *)
+let%expect_test "unsupported format offers nothing" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_actions ~init_options:(options "YYYY-ww") ~vault_root "idea.md");
+  [%expect {| |}]
+;;
+
+(** {1 The command}
+
+    [workspace/executeCommand] decides {i what} should happen; the adapter
+    performs it.  See {!page-"feature-daily-notes"}. *)
+
+let show_command ?(arguments : Yojson.Safe.t list option) ~(vault_root : string) command =
+  let s = start_server ~init_options:(options "YYYY-MM-DD") ~today ~vault_root () in
+  match Server.execute_command s ~command ~arguments with
+  | None -> print_endline "no intent"
+  | Some { uri; create } ->
+    printf
+      "%s create=%s\n"
+      (Server.rel_path_of_uri s uri)
+      (match create with
+       | None -> "none"
+       | Some edit -> String.concat ~sep:"," (document_change_kinds edit))
+;;
+
+let%expect_test "existing note is opened without an edit" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_command
+      ~vault_root
+      ~arguments:[ `String "journal/2026-07-26.md"; `Bool true ]
+      Server.daily_note_command);
+  [%expect {| journal/2026-07-26.md create=none |}]
+;;
+
+let%expect_test "missing note is created, then opened" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_command
+      ~vault_root
+      ~arguments:[ `String "journal/2026-07-27.md"; `Bool true ]
+      Server.daily_note_command);
+  [%expect {| journal/2026-07-27.md create=create |}]
+;;
+
+(* An editor may send anything; neither an unknown command nor unusable
+   arguments should reach the disk. *)
+let%expect_test "unknown command and bad arguments yield no intent" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_command
+      ~vault_root
+      ~arguments:[ `String "x.md"; `Bool true ]
+      "some.other.command";
+    show_command ~vault_root Server.daily_note_command;
+    show_command ~vault_root ~arguments:[ `Int 3 ] Server.daily_note_command);
+  [%expect
+    {|
+    no intent
+    no intent
+    no intent
+    |}]
+;;

--- a/pkg/oystermark/tests/lsp/test_daily_notes.ml
+++ b/pkg/oystermark/tests/lsp/test_daily_notes.ml
@@ -109,13 +109,14 @@ let%expect_test "unsupported format offers nothing" =
 
 (* ...and says why.  Offering nothing is also what a correctly configured
    server does when it has nothing to offer, so the rejection has to be
-   reported for the two to be distinguishable.  The adapter turns this into a
-   [window/showMessage] at initialize. *)
+   reported for the two to be distinguishable.  It joins the configuration
+   warnings, which the adapter turns into [window/showMessage] at initialize —
+   see {!page-"feature-configuration".tolerance}. *)
 let%expect_test "a rejected format is reported" =
   let show ?init_options () =
     with_tmp_vault ~files (fun vault_root ->
       let s = start_server ?init_options ~today ~vault_root () in
-      print_s [%sexp (Server.daily_notes_error s : string option)])
+      print_s [%sexp (Server.config_warnings s : string list)])
   in
   show ~init_options:(options "YYYY-ww") ();
   show ~init_options:(options "/YYYY-MM-DD") ();
@@ -124,8 +125,8 @@ let%expect_test "a rejected format is reported" =
   show ();
   [%expect
     {|
-    ("unsupported format token 'w'")
-    ("format must not start with /")
+    ("daily notes disabled: unsupported format token 'w'")
+    ("daily notes disabled: format must not start with /")
     ()
     ()
     |}]

--- a/pkg/oystermark/tests/lsp/test_daily_notes.ml
+++ b/pkg/oystermark/tests/lsp/test_daily_notes.ml
@@ -57,6 +57,7 @@ let%expect_test "actions from a daily note: calendar plus previous/next" =
     Create yesterday's daily note    "journal/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026-07-27.md" true
     Open previous daily note         "journal/2026-07-10.md" false
+    Insert link to today's daily note no command
     Insert oysterlsp command block   no command
     |}]
 ;;
@@ -73,6 +74,7 @@ let%expect_test "previous and next from the middle of the range" =
     Create tomorrow's daily note     "journal/2026-07-27.md" true
     Open previous daily note         "journal/2026-07-03.md" false
     Open next daily note             "journal/2026-07-26.md" false
+    Insert link to today's daily note no command
     Insert oysterlsp command block   no command
     |}]
 ;;
@@ -86,6 +88,7 @@ let%expect_test "actions from an ordinary note" =
     Open today's daily note          "journal/2026-07-26.md" false
     Create yesterday's daily note    "journal/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026-07-27.md" true
+    Insert link to today's daily note no command
     Insert oysterlsp command block   no command
     |}]
 ;;
@@ -99,6 +102,7 @@ let%expect_test "nested format" =
     Create today's daily note        "journal/2026/07/2026-07-26.md" true
     Create yesterday's daily note    "journal/2026/07/2026-07-25.md" true
     Create tomorrow's daily note     "journal/2026/07/2026-07-27.md" true
+    Insert link to today's daily note no command
     Insert oysterlsp command block   no command
     |}]
 ;;
@@ -187,5 +191,94 @@ let%expect_test "unknown command and bad arguments yield no intent" =
     no intent
     no intent
     no intent
+    |}]
+;;
+
+(** {1 Linking instead of opening}
+
+    See {!page-"feature-daily-notes".link}.  The one action in the family that
+    needs no [window/showDocument]: it writes a link, and go-to-definition
+    follows it. *)
+
+(** The link action offered at [rel_path], as the operations its edit performs
+    and the text it writes. *)
+let show_link ?(init_options = options "YYYY-MM-DD") ~(vault_root : string) rel_path =
+  let s = start_server ~init_options ~today ~vault_root () in
+  did_open s ~rel_path;
+  Server.code_action
+    s
+    ~rel_path
+    ~start_line:0
+    ~start_character:6
+    ~end_line:0
+    ~end_character:6
+    ()
+  |> List.filter ~f:(fun (a : CodeAction.t) ->
+    String.is_prefix a.title ~prefix:"Insert link")
+  |> List.iter ~f:(fun (a : CodeAction.t) ->
+    Option.iter a.edit ~f:(fun edit ->
+      printf
+        "%s: [%s] %s\n"
+        a.title
+        (String.concat ~sep:"; " (document_change_kinds edit))
+        (String.concat ~sep:" " (inserted_texts edit))))
+;;
+
+(* Today's note exists: nothing to create, just the link. *)
+let%expect_test "links to an existing daily note" =
+  with_tmp_vault ~files (fun vault_root -> show_link ~vault_root "idea.md");
+  [%expect {| Insert link to today's daily note: [text-edits] [[2026-07-26]] |}]
+;;
+
+(* When today's note is missing the same action creates it, so the link it
+   writes resolves immediately rather than landing unresolved. *)
+let%expect_test "creates today's note when it is missing" =
+  let files =
+    List.filter files ~f:(fun (p, _) -> not (String.equal p "journal/2026-07-26.md"))
+  in
+  with_tmp_vault ~files (fun vault_root -> show_link ~vault_root "idea.md");
+  [%expect {| Insert link to today's daily note: [create; text-edits] [[2026-07-26]] |}]
+;;
+
+(* The link is the base name, not the path: resolution matches a path
+   subsequence, so the folders need not be spelled out. *)
+let%expect_test "a nested format still links by base name" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_link ~init_options:(options "YYYY/MM/YYYY-MM-DD") ~vault_root "idea.md");
+  [%expect {| Insert link to today's daily note: [create; text-edits] [[2026-07-26]] |}]
+;;
+
+(* Nothing resolves with the feature disabled, so there is nothing to link. *)
+let%expect_test "no link action when daily notes are disabled" =
+  with_tmp_vault ~files (fun vault_root ->
+    show_link ~init_options:(options "YYYY-ww") ~vault_root "idea.md");
+  [%expect {| |}]
+;;
+
+(* The action appears in every menu in the vault, which is not always wanted;
+   [linkAction] withdraws it without disabling daily notes.  See
+   {!page-"feature-configuration"}. *)
+let%expect_test "linkAction: false withdraws the action, and nothing else" =
+  let init_options : Yojson.Safe.t =
+    `Assoc
+      [ ( "dailyNotes"
+        , `Assoc
+            [ "format", `String "YYYY-MM-DD"
+            ; "folder", `String "journal"
+            ; "linkAction", `Bool false
+            ] )
+      ]
+  in
+  with_tmp_vault ~files (fun vault_root ->
+    show_link ~init_options ~vault_root "idea.md";
+    print_endline "-- the rest of the menu:";
+    show_actions ~init_options ~vault_root "idea.md");
+  [%expect
+    {|
+    -- the rest of the menu:
+    Open today's daily note          "journal/2026-07-26.md" false
+    Create yesterday's daily note    "journal/2026-07-25.md" true
+    Create tomorrow's daily note     "journal/2026-07-27.md" true
+    Insert oysterlsp command block   no command
     |}]
 ;;

--- a/pkg/oystermark/tests/lsp/test_daily_notes.ml
+++ b/pkg/oystermark/tests/lsp/test_daily_notes.ml
@@ -107,6 +107,30 @@ let%expect_test "unsupported format offers nothing" =
   [%expect {| |}]
 ;;
 
+(* ...and says why.  Offering nothing is also what a correctly configured
+   server does when it has nothing to offer, so the rejection has to be
+   reported for the two to be distinguishable.  The adapter turns this into a
+   [window/showMessage] at initialize. *)
+let%expect_test "a rejected format is reported" =
+  let show ?init_options () =
+    with_tmp_vault ~files (fun vault_root ->
+      let s = start_server ?init_options ~today ~vault_root () in
+      print_s [%sexp (Server.daily_notes_error s : string option)])
+  in
+  show ~init_options:(options "YYYY-ww") ();
+  show ~init_options:(options "/YYYY-MM-DD") ();
+  show ~init_options:(options "YYYY-MM-DD") ();
+  (* Unconfigured: the default format is usable, so there is nothing to say. *)
+  show ();
+  [%expect
+    {|
+    ("unsupported format token 'w'")
+    ("format must not start with /")
+    ()
+    ()
+    |}]
+;;
+
 (** {1 The command}
 
     [workspace/executeCommand] decides {i what} should happen; the adapter

--- a/pkg/oystermark/tests/lsp/test_diagnostics.ml
+++ b/pkg/oystermark/tests/lsp/test_diagnostics.ml
@@ -120,7 +120,7 @@ let%expect_test "trace: diagnostics spans" =
 ------------ *)
 
 let%expect_test "server: unresolved link produces diagnostic on didOpen" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   open_doc s ~rel_path:"note-b.md"
   |> diagnostic_positions
   |> List.iter ~f:(fun (msg, line, char) -> printf "%d:%d %s\n" line char msg);
@@ -128,7 +128,7 @@ let%expect_test "server: unresolved link produces diagnostic on didOpen" =
 ;;
 
 let%expect_test "server: didChange republishes diagnostics" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   (* didOpen: no unresolved links *)
   let on_open = open_doc s ~rel_path:"subdir/nested.md" in
   printf "after open: %d diagnostics\n" (List.length on_open);
@@ -148,7 +148,7 @@ let%expect_test "server: didChange republishes diagnostics" =
 ;;
 
 let%expect_test "server: resolved links produce no diagnostics" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   let diags = open_doc s ~rel_path:"subdir/nested.md" in
   printf "%d diagnostics\n" (List.length diags);
   [%expect {| 0 diagnostics |}]

--- a/pkg/oystermark/tests/lsp/test_did_save.ml
+++ b/pkg/oystermark/tests/lsp/test_did_save.ml
@@ -15,7 +15,7 @@ let%expect_test "didSave refreshes diagnostics in other open docs" =
   with_tmp_vault
     ~files:[ "a.md", "# A\n\nLink: [[brand-new]]\n" ]
     (fun vault_root ->
-       let s = start_server ~vault_root in
+       let s = start_server ~vault_root () in
        (* Initial diagnostics: one unresolved-link warning in a.md. *)
        let initial = open_doc s ~rel_path:"a.md" in
        printf "initial: %d diagnostic(s)\n" (List.length initial);
@@ -43,7 +43,7 @@ let%expect_test "didSave refreshes every open document" =
       ; "b.md", "# B\n\nAlso: [[brand-new]] and [[still-missing]]\n"
       ]
     (fun vault_root ->
-       let s = start_server ~vault_root in
+       let s = start_server ~vault_root () in
        did_open s ~rel_path:"a.md";
        did_open s ~rel_path:"b.md";
        Out_channel.write_all
@@ -67,7 +67,7 @@ let%expect_test "didClose stops refreshing a document" =
   with_tmp_vault
     ~files:[ "a.md", "# A\n\nLink: [[missing]]\n"; "b.md", "# B\n" ]
     (fun vault_root ->
-       let s = start_server ~vault_root in
+       let s = start_server ~vault_root () in
        did_open s ~rel_path:"a.md";
        did_open s ~rel_path:"b.md";
        Server.did_close s ~rel_path:"a.md";

--- a/pkg/oystermark/tests/lsp/test_document_outline.ml
+++ b/pkg/oystermark/tests/lsp/test_document_outline.ml
@@ -61,7 +61,7 @@ let%expect_test "unknown file has no outline" =
 
 let%expect_test "server: documentSymbol returns a hierarchical result" =
   let vault_root = Filename.concat (Core_unix.getcwd ()) "data" in
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-a.md";
   let rec print_symbols depth (symbols : DocumentSymbol.t list) =
     List.iter symbols ~f:(fun (symbol : DocumentSymbol.t) ->

--- a/pkg/oystermark/tests/lsp/test_find_references.ml
+++ b/pkg/oystermark/tests/lsp/test_find_references.ml
@@ -124,7 +124,7 @@ let%expect_test "unit: unresolved link returns empty" =
    ============ *)
 
 let%expect_test "server: references to note-a" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   Server.references s ~rel_path:"note-b.md" ~line:2 ~character:13
   |> reference_positions s
@@ -140,7 +140,7 @@ let%expect_test "server: references to note-a" =
 ;;
 
 let%expect_test "server: no references for cursor on plain text" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-a.md";
   let result =
     Server.references s ~rel_path:"note-a.md" ~line:0 ~character:0

--- a/pkg/oystermark/tests/lsp/test_go_to_definition.ml
+++ b/pkg/oystermark/tests/lsp/test_go_to_definition.ml
@@ -32,7 +32,7 @@ let files =
 let index = Vault_helper.make_index files
 
 let%expect_test "server: wikilink to note" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:2 ~character:13 |> definition_result s
@@ -42,7 +42,7 @@ let%expect_test "server: wikilink to note" =
 ;;
 
 let%expect_test "server: wikilink to heading" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:4 ~character:10 |> definition_result s
@@ -52,7 +52,7 @@ let%expect_test "server: wikilink to heading" =
 ;;
 
 let%expect_test "server: wikilink to block id" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:6 ~character:10 |> definition_result s
@@ -66,7 +66,7 @@ let%expect_test "server: wikilink to block id" =
    See {!page-"feature-attribute-anchors"} and
    {!page-"feature-go-to-definition".target_position}. *)
 let%expect_test "server: wikilink to inline attribute anchor (column-precise)" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"anchor-source.md";
   let result =
     Server.definition s ~rel_path:"anchor-source.md" ~line:2 ~character:10
@@ -77,7 +77,7 @@ let%expect_test "server: wikilink to inline attribute anchor (column-precise)" =
 ;;
 
 let%expect_test "server: markdown link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:8 ~character:18 |> definition_result s
@@ -87,7 +87,7 @@ let%expect_test "server: markdown link" =
 ;;
 
 let%expect_test "server: unresolved link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:10 ~character:16
@@ -98,7 +98,7 @@ let%expect_test "server: unresolved link" =
 ;;
 
 let%expect_test "server: cursor not on link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.definition s ~rel_path:"note-b.md" ~line:0 ~character:2 |> definition_result s
@@ -108,7 +108,7 @@ let%expect_test "server: cursor not on link" =
 ;;
 
 let%expect_test "server: cross-directory link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"subdir/nested.md";
   let result =
     Server.definition s ~rel_path:"subdir/nested.md" ~line:2 ~character:13

--- a/pkg/oystermark/tests/lsp/test_hover.ml
+++ b/pkg/oystermark/tests/lsp/test_hover.ml
@@ -33,7 +33,7 @@ let index = Vault_helper.make_index files
 let read_file rel_path = List.Assoc.find files ~equal:String.equal rel_path
 
 let%expect_test "server: hover on wikilink to note" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   (* Line 2: "Link to [[note-a]] here." — cursor on "note-a" *)
   let result = Server.hover s ~rel_path:"note-b.md" ~line:2 ~character:13 |> hover_text in
@@ -56,7 +56,7 @@ let%expect_test "server: hover on wikilink to note" =
 ;;
 
 let%expect_test "server: hover on heading fragment" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   (* Line 4: "See [[note-a#Section One]]." *)
   let result = Server.hover s ~rel_path:"note-b.md" ~line:4 ~character:10 |> hover_text in
@@ -73,7 +73,7 @@ let%expect_test "server: hover on heading fragment" =
 ;;
 
 let%expect_test "server: hover on block fragment" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   (* Line 6: "Also [[note-a#^block1]]." *)
   let result = Server.hover s ~rel_path:"note-b.md" ~line:6 ~character:10 |> hover_text in
@@ -87,7 +87,7 @@ let%expect_test "server: hover on block fragment" =
 ;;
 
 let%expect_test "server: hover on empty note" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-c.md";
   (* Line 2: "See [[empty]]." *)
   let result = Server.hover s ~rel_path:"note-c.md" ~line:2 ~character:8 |> hover_text in
@@ -101,7 +101,7 @@ let%expect_test "server: hover on empty note" =
 ;;
 
 let%expect_test "server: hover on unresolved link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   (* Line 10: "Unresolved [[missing-note]]." *)
   let result =
@@ -112,7 +112,7 @@ let%expect_test "server: hover on unresolved link" =
 ;;
 
 let%expect_test "server: hover cursor not on link" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result = Server.hover s ~rel_path:"note-b.md" ~line:0 ~character:2 |> hover_text in
   print_s [%sexp (result : string option)];

--- a/pkg/oystermark/tests/lsp/test_inlay_hints.ml
+++ b/pkg/oystermark/tests/lsp/test_inlay_hints.ml
@@ -87,7 +87,7 @@ let%expect_test "unit: partial range" =
    ============ *)
 
 let%expect_test "server: inlay hints for note-a" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-a.md";
   Server.inlay_hint s ~rel_path:"note-a.md" ~start_line:0 ~end_line:20
   |> inlay_hint_positions
@@ -100,7 +100,7 @@ let%expect_test "server: inlay hints for note-a" =
 ;;
 
 let%expect_test "server: inlay hints for file with no refs" =
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   let result =
     Server.inlay_hint s ~rel_path:"note-b.md" ~start_line:0 ~end_line:20

--- a/pkg/oystermark/tests/lsp/test_rename.ml
+++ b/pkg/oystermark/tests/lsp/test_rename.ml
@@ -34,7 +34,10 @@ let show_applied edits =
       List.filter edits ~f:(fun (e : Lsp_lib.Rename.edit) ->
         String.equal e.rel_path rel_path)
     in
-    printf "--- %s\n%s" rel_path (apply_edits (Option.value_exn (read_file rel_path)) edits))
+    printf
+      "--- %s\n%s"
+      rel_path
+      (apply_edits (Option.value_exn (read_file rel_path)) edits))
 ;;
 
 let%expect_test "rename heading from its definition updates wikilinks and markdown link" =
@@ -159,8 +162,12 @@ let%expect_test "rename note preserves aliases and fragments" =
    the definition. See {!Lsp_lib.Rename.attr_id_offset}. *)
 let collide_files =
   [ ( "collide.md"
-    , "# Doc\n\nSee [[collide#note]] first.\n\n{#note-extended}\n> Longer.\n\n{#note}\n> Short.\n"
-    )
+    , "# Doc\n\n\
+       See [[collide#note]] first.\n\n\
+       {#note-extended}\n\
+       > Longer.\n\n\
+       {#note}\n\
+       > Short.\n" )
   ]
 ;;
 
@@ -186,7 +193,8 @@ let%expect_test "attribute rename is not confused by prefixes or link fragments"
   in
   show edits;
   printf "---\n%s" (apply_edits content edits);
-  [%expect {|
+  [%expect
+    {|
     collide.md [21-25] -> renamed
     collide.md [66-70] -> renamed
     ---
@@ -204,7 +212,7 @@ let%expect_test "attribute rename is not confused by prefixes or link fragments"
 
 let%expect_test "server: note rename includes text edits and a file operation" =
   let vault_root = Filename.concat (Core_unix.getcwd ()) "data" in
-  let s = start_server ~vault_root in
+  let s = start_server ~vault_root () in
   did_open s ~rel_path:"note-b.md";
   Server.rename s ~rel_path:"note-b.md" ~line:2 ~character:13 ~new_name:"renamed"
   |> document_change_kinds

--- a/specification/obsidian/daily-notes.md
+++ b/specification/obsidian/daily-notes.md
@@ -1,0 +1,167 @@
+# Daily Notes
+
+Reference specification of Obsidian's **Daily notes** core plugin: its
+settings, the path it computes for a given date, and the inverse — how a file
+path is parsed back into a date.
+
+Sources, all verified rather than recalled:
+
+- Obsidian 1.13.3 application bundle
+  (`~/Library/Application Support/obsidian/obsidian-1.13.3.asar`), the daily
+  notes core plugin;
+- the Obsidian CLI (`/Applications/Obsidian.app/Contents/MacOS/obsidian`,
+  `daily*` commands), probed against a real vault;
+- `.obsidian/daily-notes.json` from two live vaults.
+
+The public plugin API (`vendor/obsidian-api/obsidian.d.ts`, 1.12.3) exposes
+*nothing* about daily notes — it is an internal core plugin, reachable only via
+`app.internalPlugins.getEnabledPluginById("daily-notes")`. So there is no
+vendor-blessed schema; what follows is the observed behavior.
+
+## Settings
+
+Stored in `.obsidian/daily-notes.json`. Every key is optional, and the file is
+absent entirely until a setting is changed:
+
+| Key | Type | Default | Settings-tab label |
+|---|---|---|---|
+| `format` | string, a [moment.js format](https://momentjs.com/docs/#/displaying/format/) | `YYYY-MM-DD` | Date format / Custom format |
+| `folder` | string, vault-relative folder path | app's "default location for new notes" | New file location |
+| `template` | string, vault-relative file path | none | Template file location |
+
+A real example (`format` only, the other keys never set):
+
+```json
+{
+  "format": "YYYY/MM/YYYY-MM-DD"
+}
+```
+
+`autorun` is legacy: on load the plugin migrates it to the app-level
+`openBehavior: "daily"` config and deletes the key.
+
+The settings tab shows a dropdown of preset formats plus a `custom` entry; the
+choice is not itself persisted, only the resulting `format` string.
+
+### Format validation
+
+A format is rejected by the settings UI when any of:
+
+1. it starts with `/`;
+2. `moment().format(f)` contains characters illegal in a filename;
+3. it does not round-trip: `moment(moment().format(f), f, true).isValid()` is
+   false (strict parsing).
+
+Rule 3 is the important one — the format must be *invertible*, because the
+prev/next commands parse filenames back into dates with the same format.
+
+## Path computation
+
+`getDailyNote(date?)`, decoded from the bundle:
+
+```
+date   ← date ?? now
+name   ← date.format(format)        // failure ⇒ notice, abort
+name   ← name.trim()
+parent ← folder is a non-empty string
+           ? vault folder at normalizePath(folder)   // not a folder ⇒ notice, abort
+           : fileManager.getNewFileParent("")        // app's new-note location
+path   ← parent prefix + name + ".md"
+existing ← vault.getAbstractFileByPathInsensitive(path)
+  existing is a file      ⇒ return it
+  existing is a folder    ⇒ abort
+  nothing                 ⇒ create it (see below)
+```
+
+Consequences worth naming:
+
+- **The format may contain `/`.** `YYYY/MM/YYYY-MM-DD` yields
+  `2026/07/2026-07-26.md`; intermediate folders are created on demand. Verified
+  by `obsidian daily:path` on a vault with that format, which returns
+  `2026/07/2026-07-26.md`.
+- **Lookup is case-insensitive** (`getAbstractFileByPathInsensitive`), so an
+  existing `2026-07-26.md` is reused even if the format would produce different
+  casing.
+- **An unset `folder` does not mean vault root**; it means the app's "default
+  location for new notes", which is separately configurable (and *does* default
+  to the root).
+- The name is trimmed, so a format with trailing whitespace is tolerated.
+
+### Creation
+
+- With `template` set: the path is normalized, `.md` is appended when it has no
+  extension, and the file must exist (otherwise notice + abort). Its content is
+  read and run through the template variable resolver with `title` bound to the
+  computed note name, then written to the new note.
+- Without: an empty note is created.
+
+## Reverse: path → date
+
+`iterateDailyNotes` walks the daily-note folder recursively and, for each `.md`
+file, takes the path *relative to that folder*, strips the extension, and
+parses it with `moment(rel, format, true)` — strict. Valid parses are daily
+notes; everything else is ignored.
+
+Two asymmetries with `getDailyNote`:
+
+- it uses `getFolder()`, which falls back to the **vault root** when `folder` is
+  unset — not to the app's new-note location;
+- it is the only place a daily note is *recognized*, so recognition is
+  round-trip-based: a file is a daily note iff its relative path strictly parses
+  under the current format.
+
+## Commands
+
+| Command id | Name | Behavior |
+|---|---|---|
+| `daily-notes` | Open today's daily note | `getDailyNote()` — **creates** the note when missing, then opens it |
+| `daily-notes:goto-prev` | Open previous daily note | previous **existing** daily note strictly before the current file's date |
+| `daily-notes:goto-next` | Open next daily note | next **existing** daily note strictly after it |
+
+Note what prev/next are *not*: they are not "yesterday" and "tomorrow". They
+are enabled only when the currently active file itself parses as a daily note
+(`getCurrentFileDateTimestamp()`), they never create anything, and they skip
+gaps — with notes on the 3rd and the 10th, prev from the 10th lands on the 3rd.
+When there is nothing to go to, the user gets "There's no daily note before
+this one."
+
+There is no built-in command for an arbitrary date, for yesterday, or for
+tomorrow.
+
+Beyond the command palette, the plugin also contributes: a ribbon icon, an
+"Insert link into daily note" file-menu item, and a text-menu item that appends
+selected text to today's note.
+
+## CLI surface
+
+Obsidian 1.13's CLI (enabled per-install; `"cli": true` in `obsidian.json`)
+exposes:
+
+| Command | Effect |
+|---|---|
+| `daily` | Open the daily note (creating it — same `getDailyNote` path) |
+| `daily:path` | Print the vault-relative path of today's daily note |
+| `daily:read` | Print its contents |
+| `daily:append` / `daily:prepend` | Add content, optionally opening it |
+
+All of them are today-only; none takes a date argument. `daily:path` is the
+useful probe: it is read-only and shows exactly how the settings resolve.
+
+```console
+$ obsidian daily:path vault=Oyster
+2026/07/2026-07-26.md
+```
+
+## Notes for an Oystermark implementation
+
+- The moment.js format is the whole interoperability contract. To read a vault
+  that Obsidian also opens, the same `format` string must produce the same path,
+  which means supporting at least the tokens people actually use: `YYYY`, `YY`,
+  `MM`, `M`, `MMM`, `MMMM`, `DD`, `D`, `Do`, `ddd`, `dddd`, `ww`, `W`, `gggg`,
+  and literal text in `[...]`.
+- Reading `.obsidian/daily-notes.json` directly is the cheapest way to stay in
+  sync with a vault that is also used from Obsidian; a native Oystermark
+  setting can override it.
+- Obsidian's prev/next semantics (existing notes, not calendar days) and a
+  yesterday/tomorrow semantics (calendar days, create on demand) are different
+  features. Both are defensible; they should not be conflated under one name.


### PR DESCRIPTION
Three user-facing LSP features, the configuration file they need, and the
parser work underneath them.

## Features

**Daily notes** — code actions to open or create today's / yesterday's /
tomorrow's note, and to step to the previous or next *existing* one relative
to the note you are in. Formats are a subset of the moment.js tokens and may
contain `/` to nest notes in folders. Spec:
`docs/feature-daily-notes.mld`.

**Command blocks** — a fenced ` ```oysterlsp ` block whose lines name
commands. Each line gets a code lens carrying what a code action would, so
the command is visible and clickable rather than buried in a menu; plus a
code action on the cursor's line, completion of the names inside the block,
and a diagnostic on a name that matches nothing. The block lives in a note,
which is what makes `daily/prev` and `daily/next` meaningful — they resolve
against the host note. Dev-time only: an ordinary code block to the parser
and the renderer. Spec: `docs/feature-command-block.mld`.

**Configuration** — `oysterlsp.json` at the vault root, overriding the
client's `initializationOptions` key by key. The file wins because it
describes the *vault*, not the editor looking at it. Nothing here can fail
initialization: every fallback is reported as a startup message, since a
setting ignored in silence is indistinguishable from one that does not
exist. `oysterlsp.schema.json` publishes the same schema for editors, and
`oystermark-lsp --print-default-config` writes a starting file. Spec:
`docs/feature-configuration.mld`.

## Two things worth a reviewer's attention

**Commands never reached their handler** (`b8d04ca`). `workspace/executeCommand`
was answered from `on_request_unhandled`, but linol dispatches `ExecuteCommand`
to a dedicated hook whose default returns `` `Null ``. The branch was
unreachable, so the daily-note commands had never worked through the adapter in
any client. The handler body was correct; it hung off the wrong hook. The
in-process tests could not see it — they drive `Server` directly, and `main.ml`
is the one file `dune runtest` does not reach — so `scripts/smoke.py` drives a
real stdio session and asserts what an editor observes. It fails on a binary
built before that commit and passes after.

**`window/showDocument` is optional, and some editors do not implement it.**
Focusing a note is the one effect the server cannot perform itself. Where the
capability is missing, an open-only command now reports the path through
`window/showMessage` instead of finishing in silence, and
`Insert link to today's daily note` offers a route that needs no capability at
all: it writes a wikilink, and go-to-definition follows it. That action is the
only one offered in every menu in the vault, so `dailyNotes.linkAction` can
withdraw it.

## Underneath

Heading identifiers now come from the parser (`Heading_slug` deprecated), djot
extensions are enabled, and anchors resolve uniformly across wikilinks and
CommonMark links — the full 2×3 matrix of {wikilink, markdown link} ×
{heading, block attribute, inline attribute} is pinned by an expect test.

## Testing

Inline expect tests beside each module, server-level tests in `tests/lsp/`, and
a drift test that holds `oysterlsp.schema.json` and the parser to the same key
set in both directions. `scripts/smoke.py` is a manual session-level check for
`main.ml`, documented in the README.