### PR TITLE
Refine struct and block id interaction

### DIFF
--- a/pkg/oystermark/lib/component/html.ml
+++ b/pkg/oystermark/lib/component/html.ml
@@ -421,11 +421,20 @@ let label_is_empty : Inline.t -> bool = function
     rather than being unwrapped. *)
 let render_struct
       ~(style : struct_style)
+      ?(meta : Meta.t = Meta.none)
       (label_kind : [ `Paragraph | `List_item ])
       c
       label
       body
   =
+  (* A keyed node carries the block id of the paragraph or list item it
+     supplanted. Emit it in the [^id] form paragraphs already use, so a
+     [#^id] fragment lands on the node and its whole body. *)
+  let id_attr =
+    match Block.Block_id.find meta with
+    | None -> ""
+    | Some (b : Block.Block_id.t) -> sprintf " id=\"^%s\"" (Block.Block_id.id b)
+  in
   let label_empty = label_is_empty label in
   let label_kind_attr =
     match label_kind with
@@ -448,7 +457,7 @@ let render_struct
   let struct_style_attr_str = struct_style_attr style in
   C.string
     c
-    {%string|<div class="keyed" data-label-kind="%{label_kind_attr}" data-style="%{struct_style_attr_str}"%{body_attr}%{emtpy_label_attr}%{single_attr}>|};
+    {%string|<div class="keyed"%{id_attr} data-label-kind="%{label_kind_attr}" data-style="%{struct_style_attr_str}"%{body_attr}%{emtpy_label_attr}%{single_attr}>|};
   (* Always emit a label span, even when empty *)
   C.string c "<span class=\"keyed-label\">";
   if not label_empty then C.inline c label;
@@ -493,9 +502,9 @@ let list_has_keyed (l : Block.List'.t) : bool =
 let keyed_list_item ~(style : struct_style) ~(tight : bool) c (item, _) =
   let render_body () =
     match Block.List_item.block item with
-    | Block.Ext_keyed ((label, body), _) ->
+    | Block.Ext_keyed ((label, body), meta) ->
       C.byte c '\n';
-      render_struct ~style `List_item c (Struct.label_key label) body
+      render_struct ~style ~meta `List_item c (Struct.label_key label) body
     | b -> item_block ~tight c b
   in
   C.string c "<li>";
@@ -658,11 +667,11 @@ let render_block
        struct_style := prev);
     C.string c "</div>\n";
     true
-  | Cmarkit.Block.Ext_keyed ((label, body), _) ->
+  | Cmarkit.Block.Ext_keyed ((label, body), meta) ->
     (* A keyed node reached here is a {e free} block (a top-level keyed node, or
        the body of another keyed node). A keyed node that is a list item's block
        is handled positionally by [render_keyed_list], not here. *)
-    render_struct ~style:!struct_style `Paragraph c (Struct.label_key label) body;
+    render_struct ~style:!struct_style ~meta `Paragraph c (Struct.label_key label) body;
     true
   | Block.List (l, _) when list_has_keyed l ->
     render_keyed_list ~style:!struct_style c l;

--- a/pkg/oystermark/lib/parse/extract.ml
+++ b/pkg/oystermark/lib/parse/extract.ml
@@ -52,11 +52,15 @@ let get_heading_section (blocks : Cmarkit.Block.t list) (heading_id : string)
 
 (** Extract the block that {!Cmarkit.Block.Block_id.t} points to.
 
-    Two cases:
+    Three cases:
     - {b Inline}: the [^id] appears at the end of a paragraph with other content.
       The paragraph itself is the target.
     - {b Standalone}: the [^id] is the entire paragraph.
-      It references the previous non-blank block. *)
+      It references the previous non-blank block.
+    - {b Keyed}: the id is on a {!Cmarkit.Block.Ext_keyed} node, having been
+      forwarded from the paragraph or list item the node supplanted. The node
+      itself is the target, so the reference denotes the label {e and} everything
+      the key claimed as children -- an anchor for a whole subtree. *)
 let get_block_by_caret_id (blocks : Cmarkit.Block.t list) (id : string)
   : Cmarkit.Block.t option
   =
@@ -89,6 +93,13 @@ let get_block_by_caret_id (blocks : Cmarkit.Block.t list) (id : string)
             else (* Inline: the paragraph itself is the target *)
               Some block
           | false -> search (Some block) rest)
+       | Block.Ext_keyed ((_label, body), meta) ->
+         if has_matching_id meta
+         then Some block
+         else (
+           match search None (flatten [ body ]) with
+           | Some _ as found -> found
+           | None -> search (Some block) rest)
        | Block.Blank_line _ -> search prev rest
        | Block.List (l, _meta) ->
          (* Recurse into list items *)

--- a/pkg/oystermark/lib/vault/index.ml
+++ b/pkg/oystermark/lib/vault/index.ml
@@ -72,9 +72,19 @@ let extract_headings (doc : Cmarkit.Doc.t) : heading_entry list =
 
 (* Use Cmarkit.Folder to extract block IDs from a document. *)
 let extract_block_ids (doc : Cmarkit.Doc.t) : block_entry list =
+  let add_entry acc (meta : Cmarkit.Meta.t) : block_entry list =
+    match Cmarkit.Block.Block_id.find meta with
+    | None -> acc
+    | Some (bid : Cmarkit.Block.Block_id.t) ->
+      let loc =
+        let tl = Cmarkit.Meta.textloc meta in
+        if Cmarkit.Textloc.is_none tl then None else Some tl
+      in
+      acc @ [ ({ id = Cmarkit.Block.Block_id.id bid; loc } : block_entry) ]
+  in
   let folder =
     Cmarkit.Folder.make
-      ~block:(fun _f acc block ->
+      ~block:(fun f acc block ->
         match block with
         | Cmarkit.Block.Paragraph (_p, meta) ->
           (* TODO: block id itself points to the block that contains
@@ -82,14 +92,15 @@ let extract_block_ids (doc : Cmarkit.Doc.t) : block_entry list =
              We should get it.
              *)
           (match Cmarkit.Block.Block_id.find meta with
-           | Some (bid : Cmarkit.Block.Block_id.t) ->
-             let loc =
-               let tl = Cmarkit.Meta.textloc meta in
-               if Cmarkit.Textloc.is_none tl then None else Some tl
-             in
-             Cmarkit.Folder.ret
-               (acc @ [ ({ id = Cmarkit.Block.Block_id.id bid; loc } : block_entry) ])
+           | Some _ -> Cmarkit.Folder.ret (add_entry acc meta)
            | None -> Cmarkit.Folder.default)
+        | Cmarkit.Block.Ext_keyed ((_label, body), meta) ->
+          (* A keyed node carries the identifier of the paragraph or list item
+             it supplanted (see {!Cmarkit.Struct}), so it is an id site in its
+             own right. [Folder.ret] suppresses the traversal the folder would
+             otherwise give the body, so fold it explicitly -- otherwise ids
+             nested under a keyed node go missing. *)
+          Cmarkit.Folder.ret (Cmarkit.Folder.fold_block f (add_entry acc meta) body)
         | _ -> Cmarkit.Folder.default)
       ~inline_ext_default:(fun _f acc _i -> acc)
       ~block_ext_default:(fun _f acc _b -> acc)

--- a/pkg/oystermark/tests/expect-test/test_embed.ml
+++ b/pkg/oystermark/tests/expect-test/test_embed.ml
@@ -311,3 +311,68 @@ let%expect_test "reverse_embed: image embed reversed to wikilink" =
   render_reversed [ "a.md", "![](b.md)"; "b.md", "Hello." ] "a.md";
   [%expect {| ![[b]] |}]
 ;;
+
+(* Keyed nodes as anchors
+   ======================
+
+   A block id on a keyed node names the node and everything the key claimed, so
+   embedding it pulls in the label together with its whole subtree. See
+   specification/oyster/struct.md. *)
+
+let%expect_test "block ref: keyed subtree" =
+  render
+    [ "a.md", "![[b#^k]]"; "b.md", "Intro.\n\ntopic: ^k\n- one\n- two\n\nAfter." ]
+    "a.md";
+  [%expect
+    {|
+    <div class="embed" data-embed-depth="1">
+    <div class="keyed" id="^k" data-label-kind="paragraph" data-style="plain" data-body="list"><span class="keyed-label">topic</span>
+    <div class="keyed-body">
+    <ul>
+    <li>one</li>
+    <li>two</li>
+    </ul>
+    </div>
+    </div>
+    </div>
+    |}]
+;;
+
+let%expect_test "block ref: keyed list item" =
+  render [ "a.md", "![[b#^k]]"; "b.md", "- other\n- topic: ^k\n  - one\n  - two" ] "a.md";
+  [%expect
+    {|
+    <div class="embed" data-embed-depth="1">
+    <div class="keyed" id="^k" data-label-kind="paragraph" data-style="plain" data-body="list"><span class="keyed-label">topic</span>
+    <div class="keyed-body">
+    <ul>
+    <li>one</li>
+    <li>two</li>
+    </ul>
+    </div>
+    </div>
+    </div>
+    |}]
+;;
+
+(* The id names the outermost node of a colon chain, so the embed spans the
+   whole chain rather than the inner key alone. *)
+let%expect_test "block ref: keyed chain" =
+  render [ "a.md", "![[b#^k]]"; "b.md", "outer: inner: ^k\n- leaf" ] "a.md";
+  [%expect
+    {|
+    <div class="embed" data-embed-depth="1">
+    <div class="keyed" id="^k" data-label-kind="paragraph" data-style="plain"><span class="keyed-label">outer</span>
+    <div class="keyed-body">
+    <div class="keyed" data-label-kind="paragraph" data-style="plain" data-body="list" data-single-list-item><span class="keyed-label">inner</span>
+    <div class="keyed-body">
+    <ul>
+    <li>leaf</li>
+    </ul>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    |}]
+;;

--- a/pkg/oystermark/tests/expect-test/test_parse.ml
+++ b/pkg/oystermark/tests/expect-test/test_parse.ml
@@ -220,3 +220,158 @@ let%expect_test "block_id" =
     └───────────────────┴────────────────────┴──────────┘
     |}]
 ;;
+
+(* Keyed nodes and block IDs
+   ========================= *)
+
+(* A value segment that is nothing but a block-id marker is an empty value: the
+   marker becomes the node's identifier and the node claims what follows, the
+   way a bare "key:" does. See specification/oyster/struct.md. *)
+
+let keyed_block_id_cases =
+  [ (* The rule itself: an id-only value empties the value and claims. *)
+    "id-only value", "foo: ^x\n- bar\n- baz"
+  ; "no marker (baseline)", "foo:\n- bar\n- baz"
+    (* A marker ending a non-empty value identifies without emptying, so
+       nothing is claimed. *)
+  ; "non-empty value", "foo: v ^x\n- bar"
+    (* Markers that yield no identifier leave the value alone. *)
+  ; "not terminal", "foo: ^x extra"
+  ; "escaped", "foo: \\^x"
+    (* Rule 2: nothing to claim, so not keyed at all -- but still identified. *)
+  ; "blank continuation", "foo: ^x\n\n- bar"
+  ; "end of input", "foo: ^x"
+    (* Chains: identifier on the outermost node, marker consumed from the
+       innermost value. *)
+  ; "chain", "foo: bar: ^x\n- baz"
+  ; "chain, non-empty value", "foo: bar: v ^x"
+    (* List items build keyed nodes on their own path. *)
+  ; "list item", "- foo: ^x\n  - bar"
+  ; "list item, sibling", "- foo: ^x\n- baz"
+  ; "list item, non-empty", "- foo: bar ^x"
+  ; "list item, blank cont.", "- foo: ^x\n\n- bar"
+  ; "list item, no marker", "- foo:\n\n- bar"
+  ]
+;;
+
+let rec inline_text : Cmarkit.Inline.t -> string = function
+  | Cmarkit.Inline.Text (s, _) -> s
+  | Cmarkit.Inline.Inlines (is, _) -> String.concat (List.map is ~f:inline_text)
+  | Cmarkit.Inline.Break _ -> "\\n"
+  | Cmarkit.Inline.Code_span (cs, _) -> "`" ^ Cmarkit.Inline.Code_span.code cs ^ "`"
+  | _ -> "?"
+;;
+
+(* Compact shape: K(label){body} for a keyed node, P(text) for a paragraph,
+   [a, b] for a list. A block identifier shows as a "#id" suffix on its node. *)
+let rec block_shape (b : Cmarkit.Block.t) : string =
+  let id (m : Cmarkit.Meta.t) =
+    match Cmarkit.Block.Block_id.find m with
+    | Some bid -> "#" ^ Cmarkit.Block.Block_id.id bid
+    | None -> ""
+  in
+  match b with
+  | Cmarkit.Block.Blocks (bs, _) ->
+    String.concat ~sep:" " (List.filter_map bs ~f:non_empty_shape)
+  | Cmarkit.Block.Ext_keyed ((label, body), m) ->
+    sprintf "K%s(%s){%s}" (id m) (inline_text label) (block_shape body)
+  | Cmarkit.Block.Paragraph (p, m) ->
+    sprintf "P%s(%s)" (id m) (inline_text (Cmarkit.Block.Paragraph.inline p))
+  | Cmarkit.Block.List (l, _) ->
+    let items =
+      List.map (Cmarkit.Block.List'.items l) ~f:(fun (item, _) ->
+        block_shape (Cmarkit.Block.List_item.block item))
+    in
+    sprintf "[%s]" (String.concat ~sep:", " items)
+  | Cmarkit.Block.Blank_line _ -> ""
+  | _ -> "?"
+
+and non_empty_shape (b : Cmarkit.Block.t) : string option =
+  match block_shape b with
+  | "" -> None
+  | s -> Some s
+;;
+
+let show_newlines s = String.substr_replace_all s ~pattern:"\n" ~with_:"\\n"
+
+let%expect_test "keyed_block_id" =
+  let cols =
+    [ Ascii_table.Column.create "name" (fun (n, _, _) -> n)
+    ; Ascii_table.Column.create "input" (fun (_, i, _) -> show_newlines i)
+    ; Ascii_table.Column.create "shape" (fun (_, _, s) -> s)
+    ]
+  in
+  let rows =
+    List.map keyed_block_id_cases ~f:(fun (name, input) ->
+      name, input, block_shape (Cmarkit.Doc.block (Parse.of_string input)))
+  in
+  print_string (Ascii_table.to_string_noattr cols rows ~limit_width_to:150);
+  [%expect
+    {|
+    ┌────────────────────────┬───────────────────────┬────────────────────────────────┐
+    │ name                   │ input                 │ shape                          │
+    ├────────────────────────┼───────────────────────┼────────────────────────────────┤
+    │ id-only value          │ foo: ^x\n- bar\n- baz │ K#x(foo: ){[P(bar), P(baz)]}   │
+    │ no marker (baseline)   │ foo:\n- bar\n- baz    │ K(foo:){[P(bar), P(baz)]}      │
+    │ non-empty value        │ foo: v ^x\n- bar      │ K#x(foo: ){P(v ^x)} [P(bar)]   │
+    │ not terminal           │ foo: ^x extra         │ K(foo: ){P(^x extra)}          │
+    │ escaped                │ foo: \^x              │ K(foo: ){P(^x)}                │
+    │ blank continuation     │ foo: ^x\n\n- bar      │ P#x(foo: ^x) [P(bar)]          │
+    │ end of input           │ foo: ^x               │ P#x(foo: ^x)                   │
+    │ chain                  │ foo: bar: ^x\n- baz   │ K#x(foo: ){K(bar: ){[P(baz)]}} │
+    │ chain, non-empty value │ foo: bar: v ^x        │ K#x(foo: ){K(bar: ){P(v ^x)}}  │
+    │ list item              │ - foo: ^x\n  - bar    │ [K#x(foo: ){[P(bar)]}]         │
+    │ list item, sibling     │ - foo: ^x\n- baz      │ [K#x(foo: ){[P(baz)]}]         │
+    │ list item, non-empty   │ - foo: bar ^x         │ [K#x(foo: ){P(bar ^x)}]        │
+    │ list item, blank cont. │ - foo: ^x\n\n- bar    │ [P#x(foo: ^x), P(bar)]         │
+    │ list item, no marker   │ - foo:\n\n- bar       │ [P(foo:), P(bar)]              │
+    └────────────────────────┴───────────────────────┴────────────────────────────────┘
+    |}]
+;;
+
+(* The rewrite is content-invisible: rendering back to CommonMark reproduces the
+   source, so an id-only marker -- which lives on no block in the keyed tree --
+   must be put back by [Struct.unkey].
+
+   Three rows below are pinned as not byte-identical to their input. None is
+   specific to block IDs; each reproduces without any marker present:
+   {ul
+   {- ["- foo: ^x\n- baz"] re-indents, because a trailing-colon item absorbs its
+      remaining siblings into a nested list. The text is preserved, the nesting
+      is not -- content-invisibility holds for inlines, not block structure.}
+   {- ["foo: \\^x"] loses the backslash: the CommonMark renderer does not
+      re-escape ["^"], and ["\\^x"] alone renders as ["^x"] too.}
+   {- The loose-list rows gain trailing blanks on their blank line.}} *)
+let%expect_test "keyed_block_id_roundtrip" =
+  let cols =
+    [ Ascii_table.Column.create "input" (fun (i, _) -> show_newlines i)
+    ; Ascii_table.Column.create "rendered" (fun (_, r) -> show_newlines r)
+    ]
+  in
+  let rows =
+    List.map keyed_block_id_cases ~f:(fun (_, input) ->
+      input, String.strip (Cmarkit_commonmark.of_doc (Parse.of_string input)))
+  in
+  print_string (Ascii_table.to_string_noattr cols rows ~limit_width_to:150);
+  [%expect
+    {|
+    ┌───────────────────────┬───────────────────────┐
+    │ input                 │ rendered              │
+    ├───────────────────────┼───────────────────────┤
+    │ foo: ^x\n- bar\n- baz │ foo: ^x\n- bar\n- baz │
+    │ foo:\n- bar\n- baz    │ foo:\n- bar\n- baz    │
+    │ foo: v ^x\n- bar      │ foo: v ^x\n- bar      │
+    │ foo: ^x extra         │ foo: ^x extra         │
+    │ foo: \^x              │ foo: ^x               │
+    │ foo: ^x\n\n- bar      │ foo: ^x\n\n- bar      │
+    │ foo: ^x               │ foo: ^x               │
+    │ foo: bar: ^x\n- baz   │ foo: bar: ^x\n- baz   │
+    │ foo: bar: v ^x        │ foo: bar: v ^x        │
+    │ - foo: ^x\n  - bar    │ - foo: ^x\n  - bar    │
+    │ - foo: ^x\n- baz      │ - foo: ^x\n  - baz    │
+    │ - foo: bar ^x         │ - foo: bar ^x         │
+    │ - foo: ^x\n\n- bar    │ - foo: ^x\n  \n- bar  │
+    │ - foo:\n\n- bar       │ - foo:\n  \n- bar     │
+    └───────────────────────┴───────────────────────┘
+    |}]
+;;

--- a/specification/oyster/struct.md
+++ b/specification/oyster/struct.md
@@ -65,9 +65,9 @@ List
         └── ListItem "baz"
 ```
 
-### Rule 2: Keyed list item with empty continuation
+### Rule 2: Keyed node with empty continuation
 
-If the next element after a colon-suffixed list item is blank (empty), the colon is not structural. The item remains a regular `ListItem` with the colon preserved as literal text.
+If the next element after a colon-suffixed node is blank (empty), the colon is not structural. The node remains a regular `ListItem` or `Paragraph` with the colon preserved as literal text.
 
 `````markdown
 - foo:
@@ -82,6 +82,22 @@ Paragraph "bar"
 ```
 
 `bar` is not a child of `foo:`. The blank line means the colon has no effect — it's just punctuation.
+
+This applies equally to a list item followed by a blank line *inside* its own list. A blank line between items makes the list loose; the resulting trailing blank is list layout, not content, and is never claimed as a body.
+
+`````markdown
+- foo:
+
+- bar
+`````
+
+```
+List (loose)
+├── ListItem "foo:"
+└── ListItem "bar"
+```
+
+`foo:` does not become a keyed node with an empty body — it is not keyed at all.
 
 ### Rule 3: Keyed list item with contiguous block content
 
@@ -190,9 +206,9 @@ A keyed node's scope (the content it claims as children) ends when:
 
 ## Interaction with Other Extensions
 
-### Wikilinks and Block IDs (separate layer)
+### Wikilinks (separate layer)
 
-Struct operates at the tree structure level only. Cross-referencing nodes via wikilinks (`[[foo]]`) or block identifiers (`^id`) is a separate layer that operates after struct transformation. These mechanisms can be used to express graph relationships (identity, equivalence) on top of the tree that struct produces.
+Struct operates at the tree structure level only. Cross-referencing nodes via wikilinks (`[[foo]]`) is a separate layer that operates after struct transformation. It expresses graph relationships (identity, equivalence) on top of the tree that struct produces.
 
 ```markdown
 - foo: ^node-foo
@@ -202,7 +218,104 @@ Struct operates at the tree structure level only. Cross-referencing nodes via wi
   - references [[foo]]
 ```
 
-Struct builds the tree; links and IDs build the graph.
+Struct builds the tree; links build the graph.
+
+### Block Identifiers
+
+A block identifier (`^id`) is a terminal suffix of a paragraph or list item. Its interaction with keying is governed by a single rule:
+
+> A value segment whose entire content is a block-id marker is an **empty value**.
+
+The marker is consumed as the keyed node's identifier rather than becoming its value. The node then behaves in every respect like a bare `foo:` — in particular, it claims following contiguous content as children. The identifier names the node *and* its subtree, in the manner of a YAML anchor.
+
+`````markdown
+foo: ^x
+- bar
+- baz
+`````
+
+```
+KeyedBlock "foo" (id = x)
+└── List
+    ├── ListItem "bar"
+    └── ListItem "baz"
+```
+
+Without this rule `^x` would be `foo`'s value, and — a value being present — the list would remain a sibling rather than a child.
+
+#### Non-empty values
+
+A marker terminating a non-empty value is an ordinary block identifier. It identifies the node, but the value remains non-empty, so no content is claimed. The marker stays part of the value's content, as it does in an ordinary paragraph.
+
+`````markdown
+foo: v ^x
+- bar
+`````
+
+```
+KeyedBlock "foo" (id = x)
+└── Paragraph "v ^x"
+List
+└── ListItem "bar"
+```
+
+#### Markers that are not identifiers
+
+The conditions on block identifiers still apply in full. A marker that is escaped, or not a terminal suffix, is literal text and yields no identifier — and therefore does not empty the value.
+
+```
+foo: \^x        ← value is the literal "^x", no identifier
+foo: ^x extra   ← value is the literal "^x extra", no identifier
+```
+
+#### Chains
+
+A chain is written as a single paragraph (or list item), and a block identifier names the block it terminates. The block that paragraph becomes is the outermost keyed node, so the identifier attaches to the **outermost** node. This holds whether or not the value is empty.
+
+`````markdown
+foo: bar: ^x
+- baz
+`````
+
+```
+KeyedBlock "foo" (id = x)
+└── KeyedBlock "bar"
+    └── List
+        └── ListItem "baz"
+```
+
+Note that the marker's two effects land on different nodes: it is consumed from the *innermost* value — which is what empties that value and makes `baz` a child of `bar` — while the identifier it yields names the *outermost* node. Consequently an interior node of a chain cannot be named directly; to name one, break the chain so that the intended node is the outermost of its own paragraph or item.
+
+`````markdown
+foo:
+- bar: ^x
+  - baz
+`````
+
+```
+KeyedBlock "foo"
+└── List
+    └── KeyedListItem "bar" (id = x)
+        └── List
+            └── ListItem "baz"
+```
+
+#### Empty continuation
+
+Rule 2 is unaffected. An id-only value with no content to claim is not structural: the node is not keyed, and the colon and the marker both remain literal text. The identifier is still attached, exactly as it would be for any paragraph.
+
+`````markdown
+foo: ^x
+
+bar
+`````
+
+```
+Paragraph "foo: ^x" (id = x)
+Paragraph "bar"
+```
+
+The same holds at end of input: a document consisting of `foo: ^x` alone is a plain paragraph carrying the identifier `x`.
 
 ## Implementation
 


### PR DESCRIPTION
- **spec/struct: define the block-id interaction**
- **struct: pin the keyed/block-id interaction**
- **vault: make a keyed node's block id reachable**
- **bump oymarkit**
